### PR TITLE
Bump to v1.1.0 — add Agents and Hooks to README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,8 @@
     {
       "name": "goldsky",
       "source": "./",
-      "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
-      "version": "1.0.0"
+      "description": "Stream real-time blockchain data to your infrastructure. Skills, agents, and hooks for building, deploying, and debugging Turbo pipelines that index onchain events from 130+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
+      "version": "1.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "goldsky",
-  "version": "1.0.0",
-  "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
+  "version": "1.1.0",
+  "description": "Stream real-time blockchain data to your infrastructure. Skills, agents, and hooks for building, deploying, and debugging Turbo pipelines that index onchain events from 130+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
   "author": {
     "name": "Goldsky"
   },

--- a/README.md
+++ b/README.md
@@ -49,6 +49,36 @@ cp -r goldsky-agent/skills/* .cursor/skills/
 | `turbo-architecture`  | Design pipeline data flows, choose streaming vs job mode, and select sinks                      |
 | `turbo-transforms`    | Write SQL, TypeScript, dynamic table, and handler transforms                                    |
 
+## Agents
+
+Specialized sub-agents for common workflows. They run in their own context with access to relevant skills.
+
+| Agent              | Model   | Description                                                                      |
+| ------------------ | ------- | -------------------------------------------------------------------------------- |
+| `pipeline-doctor`  | inherit | Diagnose pipeline issues — checks auth, status, logs, and error patterns         |
+| `pipeline-builder` | inherit | Interactive wizard to build pipelines from chain selection through deployment     |
+| `dataset-finder`   | haiku   | Quick dataset lookup — returns chain prefixes and ready-to-paste YAML snippets   |
+
+Invoke agents directly:
+
+> `@pipeline-doctor My pipeline is stuck in error state`
+
+> `@pipeline-builder I need to index ERC20 transfers from Base into PostgreSQL`
+
+> `@dataset-finder What dataset for Polygon NFTs?`
+
+## Hooks
+
+Automated guardrails that fire around pipeline deploys. No configuration needed — they activate when the plugin is installed.
+
+| Hook                  | Event        | What it does                                                              |
+| --------------------- | ------------ | ------------------------------------------------------------------------- |
+| `pre-deploy-validate` | PreToolUse   | Runs `goldsky turbo validate` before `goldsky turbo apply`, blocks if invalid |
+| `secret-check`        | PreToolUse   | Verifies all `secret_name` refs in YAML exist, blocks if missing          |
+| `post-deploy-inspect` | PostToolUse  | Suggests `goldsky turbo inspect` after a successful deploy                |
+
+Hooks require `jq` to be installed. They gracefully fall through if `jq` or the Goldsky CLI are unavailable.
+
 ## Usage
 
 You can invoke skills by name or just describe what you want in natural language:
@@ -77,6 +107,8 @@ These skills cover the full Goldsky Turbo pipeline surface:
 - **Modes** — Streaming (continuous) and Job (one-time batch with `end_block`)
 - **Lifecycle** — Deploy, list, pause, resume, restart, delete
 - **Monitoring** — Live inspect TUI, log analysis, error pattern matching
+- **Agents** — Pipeline diagnostics, interactive builder wizard, dataset lookup
+- **Hooks** — Pre-deploy validation, secret verification, post-deploy suggestions
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Bumps plugin version to `1.1.0` in `plugin.json` and `marketplace.json`
- Updates description to mention skills, agents, and hooks (previously only mentioned skills)
- Updates chain count from "20+ chains" to "130+ chains" in plugin descriptions
- Adds **Agents** section to README documenting 3 new agents (pipeline-doctor, pipeline-builder, dataset-finder)
- Adds **Hooks** section to README documenting 3 new hooks (pre-deploy-validate, secret-check, post-deploy-inspect)
- Updates "What's Covered" section to include agents and hooks

**Note:** This PR documents the agents and hooks from PRs #3 and #4. It should be merged after those PRs.

## Test plan
- [ ] Verify `plugin.json` is valid JSON and version is `1.1.0`
- [ ] Verify `marketplace.json` is valid JSON and version is `1.1.0`
- [ ] Verify README renders correctly with new Agents and Hooks sections
- [ ] Full end-to-end: install plugin → trigger a deploy → hooks should fire → invoke `@pipeline-doctor` → agent should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)