### PR TITLE
Bundle Goldsky docs MCP server in plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,11 @@
   "repository": "https://github.com/goldsky-io/goldsky-agent",
   "homepage": "https://docs.goldsky.com",
   "license": "MIT",
-  "keywords": ["goldsky", "blockchain", "pipelines", "turbo", "web3", "data"]
+  "keywords": ["goldsky", "blockchain", "pipelines", "turbo", "web3", "data"],
+  "mcpServers": {
+    "goldsky-docs": {
+      "type": "http",
+      "url": "https://docs.goldsky.com/mcp"
+    }
+  }
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -11,5 +11,11 @@
   "license": "MIT",
   "keywords": ["goldsky", "blockchain", "pipelines", "turbo", "web3", "data", "cursor"],
   "logo": "assets/logo.png",
-  "skills": "skills/"
+  "skills": "skills/",
+  "mcpServers": {
+    "goldsky-docs": {
+      "type": "http",
+      "url": "https://docs.goldsky.com/mcp"
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -106,11 +106,41 @@ These skills cover the full Goldsky Turbo pipeline surface:
 
 The `goldsky-auth-setup` skill helps you install the Goldsky CLI, log in, and select a project.
 
+## Goldsky Docs MCP Server
+
+The plugin bundles the [Goldsky docs MCP server](https://docs.goldsky.com/mcp-server), giving the AI real-time search access to the full Goldsky documentation — Subgraphs, Mirror, Turbo, and Compose — so it can look up product details, configuration references, and examples while helping you build pipelines.
+
+When installed as a Claude Code plugin, the MCP server starts automatically. No extra setup is needed.
+
+For standalone use, or in other tools, you can connect the MCP server manually:
+
+**Claude Code (CLI)**
+
+```bash
+claude mcp add --transport http goldsky-docs https://docs.goldsky.com/mcp
+```
+
+**Cursor / VS Code**
+
+Add to your MCP settings (`.cursor/mcp.json` or `.vscode/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "goldsky-docs": {
+      "type": "http",
+      "url": "https://docs.goldsky.com/mcp"
+    }
+  }
+}
+```
+
 ## Documentation
 
 - [Goldsky Docs](https://docs.goldsky.com)
 - [Turbo Pipelines Guide](https://docs.goldsky.com/turbo-pipelines/introduction)
 - [CLI Reference](https://docs.goldsky.com/turbo-pipelines/cli)
+- [MCP Server](https://docs.goldsky.com/mcp-server)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds the [Goldsky docs MCP server](https://docs.goldsky.com/mcp-server) (`https://docs.goldsky.com/mcp`) to the Claude Code plugin via the `mcpServers` field in `plugin.json`
- When the plugin is installed and enabled, the MCP server starts automatically — no manual `claude mcp add` needed
- Adds a README section with manual setup instructions for Claude Code CLI, Cursor, and VS Code

## What this enables
The AI gets real-time search access to the full Goldsky documentation (Subgraphs, Mirror, Turbo, Compose) while helping users build pipelines. This means it can look up configuration references, product details, and examples on the fly instead of relying only on the bundled skill files.

## Test plan
- [ ] Install the plugin in Claude Code and verify `goldsky-docs` appears in `/mcp` server list
- [ ] Ask a docs question like "What sinks does Mirror support?" and confirm the MCP tool is invoked
- [ ] Verify the MCP server starts automatically on plugin enable without manual config

🤖 Generated with [Claude Code](https://claude.com/claude-code)