### PR TITLE
Add Vercel skills installer support (v1.2.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "goldsky",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
   "author": {
     "name": "Goldsky"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "goldsky",
   "displayName": "Goldsky",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
   "author": {
     "name": "Goldsky"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Local skills installation artifacts
+.agents/
+.claude/
+skills-lock.json
+
+# Dependencies
+node_modules/
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Goldsky Agent
 
+[![Install with npx](https://img.shields.io/badge/install-npx%20skills%20add-blue)](https://github.com/goldsky-io/goldsky-agent#installation)
+[![Skills](https://img.shields.io/badge/skills-10-green)](#skills)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 AI-powered tools for streaming real-time blockchain data. Build, deploy, and debug Turbo pipelines that index onchain events from 130+ chains into PostgreSQL, ClickHouse, Kafka, and more.
 
 ## Quick Start
@@ -16,16 +20,27 @@ Just describe what you need in natural language — the right skill is selected 
 
 ## Installation
 
-**Claude Code**
+**Recommended: Universal Skills Installer**
+
+```bash
+npx skills add goldsky-io/goldsky-agent -a claude-code
+```
+
+Works with Claude Code, Cursor, OpenCode, Codex, and 30+ other AI agents.
+
+**Claude Code (Plugin Marketplace)**
 
 ```
 /plugin marketplace add goldsky-io/goldsky-agent
 /plugin install goldsky@goldsky-agent
 ```
 
-**Cursor**
+<details>
+<summary>Other installation methods</summary>
 
-Clone the repo and add it as a local plugin:
+**Cursor (Local Plugin)**
+
+Clone and add to Cursor settings:
 
 ```bash
 git clone https://github.com/goldsky-io/goldsky-agent.git
@@ -38,9 +53,6 @@ Then add the path to your Cursor settings (`Settings > Cursor Settings > JSON`):
   "plugins.local": ["/absolute/path/to/goldsky-agent"]
 }
 ```
-
-<details>
-<summary>Other installation methods</summary>
 
 **Claude Code — load from local directory**
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ Just describe what you need in natural language — the right skill is selected 
 **Recommended: Universal Skills Installer**
 
 ```bash
-npx skills add goldsky-io/goldsky-agent -a claude-code
+npx skills add goldsky-io/goldsky-agent
 ```
 
-Works with Claude Code, Cursor, OpenCode, Codex, and 30+ other AI agents.
+The installer will prompt you to select your AI agent, or specify directly:
+
+```bash
+npx skills add goldsky-io/goldsky-agent -a claude-code  # or cursor, opencode, etc.
+```
+
+Works with 30+ AI agents including Claude Code, Cursor, OpenCode, and Codex.
 
 **Claude Code (Plugin Marketplace)**
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,48 @@
+# Goldsky Agent Skills
+
+AI-powered tools for building, deploying, and debugging Turbo pipelines that stream real-time blockchain data from 130+ chains.
+
+## Available Skills
+
+### Pipeline Building
+- **turbo-builder** - Interactive wizard for creating pipelines step-by-step
+- **turbo-pipelines** - YAML configuration reference (sources, transforms, sinks)
+- **turbo-transforms** - SQL, TypeScript, and dynamic table transforms
+- **turbo-architecture** - Design patterns and architecture guidance
+
+### Pipeline Operations
+- **turbo-lifecycle** - Pause, resume, restart, delete commands
+- **turbo-monitor-debug** - Error patterns, log analysis, debugging
+- **turbo-doctor** - Interactive troubleshooting workflows
+
+### Data & Configuration
+- **datasets** - Chain prefixes, dataset types, 130+ chains
+- **secrets** - Credential management for sinks (PostgreSQL, ClickHouse, Kafka)
+- **auth-setup** - CLI installation and authentication
+
+## Quick Start
+
+```bash
+# Install all skills
+npx skills add goldsky-io/goldsky-agent -a claude-code
+
+# Verify installation
+claude  # then ask "Build me a pipeline for USDC transfers"
+```
+
+## Examples
+
+**"Build me a pipeline for USDC transfers on Base"**
+→ Uses: turbo-builder, turbo-pipelines, datasets, secrets
+
+**"My pipeline is stuck in error state"**
+→ Uses: turbo-doctor, turbo-monitor-debug
+
+**"What dataset for Polygon NFTs?"**
+→ Uses: datasets
+
+## Documentation
+
+- [Goldsky Docs](https://docs.goldsky.com)
+- [GitHub Repository](https://github.com/goldsky-io/goldsky-agent)
+- [Installation Guide](https://github.com/goldsky-io/goldsky-agent#installation)

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -24,10 +24,10 @@ AI-powered tools for building, deploying, and debugging Turbo pipelines that str
 
 ```bash
 # Install all skills
-npx skills add goldsky-io/goldsky-agent -a claude-code
+npx skills add goldsky-io/goldsky-agent
 
-# Verify installation
-claude  # then ask "Build me a pipeline for USDC transfers"
+# The installer will prompt you to select your AI agent
+# Or specify directly: npx skills add goldsky-io/goldsky-agent -a <agent-name>
 ```
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@goldsky/agent-skills",
+  "version": "1.2.0",
+  "description": "AI-powered tools for streaming real-time blockchain data. Build, deploy, and debug Turbo pipelines.",
+  "keywords": [
+    "goldsky",
+    "blockchain",
+    "pipelines",
+    "turbo",
+    "web3",
+    "data",
+    "skills",
+    "ai-agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/goldsky-io/goldsky-agent.git"
+  },
+  "homepage": "https://docs.goldsky.com",
+  "license": "MIT",
+  "author": {
+    "name": "Goldsky",
+    "url": "https://goldsky.com"
+  },
+  "scripts": {
+    "validate": "npx skills add . --list"
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for Vercel's `npx skills` CLI installer, making Goldsky skills easier to discover, install, and update across 30+ AI agents.

## Changes

- ✅ Add `npx skills` as recommended installation method in README
- ✅ Create SKILLS.md for skills.sh directory landing page
- ✅ Add package.json for npm ecosystem compatibility
- ✅ Update version to 1.2.0 across all plugin manifests
- ✅ Add installation badges to README
- ✅ Add .gitignore for local installation artifacts
- ✅ Use generic installation command (works with all agents)
- ✅ Maintain backward compatibility with existing methods

## Testing

- [x] Local install: `npx skills add . --list`
- [x] Skill discovery: All 10 skills detected
- [x] Supporting files copied correctly (templates, data, references)
- [x] Skills symlinked to Claude Code successfully

## Installation

After merge, users can install via:

```bash
npx skills add goldsky-io/goldsky-agent
```

The installer will prompt for agent selection, or users can specify directly:
```bash
npx skills add goldsky-io/goldsky-agent -a <agent-name>
```

## Compatibility

All existing installation methods continue to work:
- Claude plugin marketplace
- Cursor local plugin
- Manual copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)