### PR TITLE
feat(datasets): add verified schemas from Goldsky docs

### DIFF
--- a/agents/goldsky.md
+++ b/agents/goldsky.md
@@ -1,0 +1,33 @@
+---
+name: goldsky
+description: "Goldsky Turbo pipeline expert. Builds, debugs, and manages blockchain data pipelines."
+---
+
+# Goldsky Agent
+
+You help users build, deploy, and manage Goldsky Turbo pipelines that stream blockchain data to their infrastructure.
+
+## Pipeline YAML Validation Rule
+
+### MANDATORY: Validate Before Presenting
+
+When generating or modifying a complete Turbo pipeline YAML, you MUST validate it before showing it to the user. No exceptions.
+
+A YAML block is "complete" if it contains all three of: a `name` field, a `sources` section, and a `sinks` section. Partial snippets (a single source, sink, or transform block shown during the building process) do not require pre-validation.
+
+### CLI mode (Bash available)
+
+1. Write the YAML to a file (e.g., `<pipeline-name>.yaml`)
+2. Run `goldsky turbo validate -f <pipeline-name>.yaml`
+3. If validation fails, fix the issues and re-validate
+4. Only after validation passes, present the YAML to the user
+
+Do NOT show complete pipeline YAML in a code block before validation passes.
+
+### Reference mode (Bash NOT available)
+
+You cannot run `goldsky turbo validate`, so you MUST perform a structural self-check before presenting complete pipeline YAML. Use the checklist in `skills/turbo-pipelines/references/validation-checklist.md`.
+
+Present the checklist results alongside the YAML and add a note:
+
+> This YAML was structurally checked but not validated with the CLI. Run `goldsky turbo validate -f <file>.yaml` before deploying.

--- a/hooks/scripts/pre-deploy-validate.sh
+++ b/hooks/scripts/pre-deploy-validate.sh
@@ -64,4 +64,5 @@ VALIDATE_OUTPUT=$(goldsky turbo validate "$YAML_FILE" 2>&1) || {
 }
 
 # Validation passed — allow the deploy
+echo "Hook: pre-deploy-validate — Validation passed for $YAML_FILE"
 exit 0

--- a/skills/datasets/SKILL.md
+++ b/skills/datasets/SKILL.md
@@ -172,6 +172,202 @@ All datasets use version `1.1.0`:
 
 ---
 
+## Dataset Schemas
+
+> **Source:** [docs.goldsky.com](https://docs.goldsky.com/turbo-pipelines/sources/solana.md). Do not use field names not listed here — ask the user to run `goldsky dataset list` to inspect unknown schemas.
+
+### Solana
+
+#### `solana.transactions`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `index` | integer | tx position in block |
+| `block_slot` | integer | slot number |
+| `block_hash` | string | |
+| `block_timestamp` | timestamp | |
+| `signature` | string | transaction signature |
+| `recent_block_hash` | string | |
+| `fee` | integer | in lamports |
+| `status` | integer | 1 = success |
+| `err` | string \| null | error if failed |
+| `accounts` | string[] | **all** involved accounts |
+| `balance_changes` | object[] | `{account, before, after}` in lamports |
+| `log_messages` | string[] | program execution logs |
+| `compute_units_consumed` | integer | |
+
+> **No `from_address` or `to_address` on Solana transactions** — use `accounts` array instead.
+
+#### `solana.transactions_with_instructions`
+All fields from `solana.transactions` plus:
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `pre_token_balances` | object[] | token balances before tx |
+| `post_token_balances` | object[] | token balances after tx |
+| `instructions` | object[] | see below |
+
+**Instruction object fields:** `id`, `index`, `parent_index`, `block_slot`, `block_timestamp`, `block_hash`, `tx_fee`, `tx_index`, `program_id`, `data` (base58), `accounts` (string[]), `status`, `err`
+
+#### `solana.instructions`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `index` | integer | position in tx |
+| `parent_index` | integer \| null | for inner instructions |
+| `block_slot` | integer | |
+| `block_timestamp` | timestamp | |
+| `block_hash` | string | |
+| `program_id` | string | executing program address |
+| `data` | string | base58 encoded |
+| `accounts` | string[] | instruction accounts |
+| `status` | integer | |
+| `err` | string \| null | |
+
+#### `solana.token_transfers`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `token_mint_address` | string | mint address |
+| `from_token_account` | string | source token account |
+| `to_token_account` | string | dest token account |
+| `amount` | number | raw amount |
+| `decimals` | integer | token decimals |
+| `block_slot` | integer | |
+| `block_timestamp` | timestamp | |
+| `signature` | string | tx signature |
+
+#### `solana.native_balances`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `account` | string | account pubkey |
+| `amount_before` | integer | lamports |
+| `amount_after` | integer | lamports |
+| `block_slot` | integer | |
+
+#### `solana.blocks`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `slot` | integer | |
+| `parent_slot` | integer | |
+| `hash` | string | |
+| `timestamp` | timestamp | |
+| `height` | integer | |
+| `previous_block_hash` | string | |
+| `transaction_count` | integer | |
+| `leader` | string | validator pubkey |
+| `leader_reward` | integer | lamports |
+| `skipped` | boolean | |
+
+#### `solana.rewards`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `block_slot` | integer | |
+| `block_hash` | string | |
+| `block_timestamp` | timestamp | |
+| `pub_key` | string | validator pubkey |
+| `lamports` | integer | reward amount |
+| `post_balance` | integer | balance after reward |
+| `reward_type` | string | |
+| `commission` | integer | |
+
+#### `solana.token_balances`
+> **Schema not fully documented** — do not guess field names. Inspect with `goldsky dataset list | grep solana.token_balances`.
+
+---
+
+### EVM Chains
+
+#### `<chain>.raw_logs` / `<chain>.logs`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `block_number` | integer | |
+| `block_hash` | string | |
+| `transaction_hash` | string | |
+| `transaction_index` | integer | |
+| `log_index` | integer | |
+| `address` | string | contract address (lowercase) |
+| `data` | string | hex encoded event data |
+| `topics` | string | comma-separated hex topic hashes |
+| `block_timestamp` | integer | unix timestamp |
+
+> `topics` is a comma-separated string, not an array. Topic 0 is the event signature hash.
+
+#### `<chain>.raw_transactions`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `hash` | string | |
+| `nonce` | integer | |
+| `block_hash` | string | |
+| `block_number` | integer | |
+| `transaction_index` | integer | |
+| `from_address` | string | |
+| `to_address` | string | |
+| `value` | decimal | ETH value in wei |
+| `gas` | decimal | |
+| `gas_price` | decimal | |
+| `input` | string | hex calldata |
+| `transaction_type` | integer | |
+| `block_timestamp` | integer | unix timestamp |
+| `receipt_gas_used` | decimal | |
+| `receipt_contract_address` | string \| null | if contract creation |
+| `receipt_status` | integer | 1 = success |
+| `receipt_effective_gas_price` | decimal | |
+
+> L2 chains also include: `receipt_l1_fee`, `receipt_l1_gas_used`, `receipt_l1_gas_price`, `receipt_l1_fee_scalar`
+
+#### `<chain>.blocks`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `number` | integer | block number |
+| `hash` | string | |
+| `parent_hash` | string | |
+| `miner` | string | |
+| `gas_limit` | integer | |
+| `gas_used` | integer | |
+| `timestamp` | integer | unix timestamp |
+| `transaction_count` | integer | |
+| `base_fee_per_gas` | integer | |
+| `difficulty` | double | |
+
+#### `<chain>.erc20_transfers`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `sender` | string | from address |
+| `recipient` | string | to address |
+| `amount` | decimal | token amount |
+| `address` | string | token contract address |
+| `block_number` | integer | |
+| `block_timestamp` | integer | unix timestamp |
+| `block_hash` | string | |
+| `transaction_hash` | string | |
+| `transaction_index` | integer | |
+| `log_index` | integer | |
+
+#### `<chain>.erc721_transfers`
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | |
+| `from_address` | string | |
+| `to_address` | string | |
+| `token_id` | decimal | |
+| `address` | string | NFT contract address |
+| `block_number` | integer | |
+| `block_timestamp` | integer | unix timestamp |
+| `block_hash` | string | |
+| `transaction_hash` | string | |
+| `transaction_index` | integer | |
+| `log_index` | integer | |
+
+---
+
 ## Dataset Name Format
 
 All datasets follow the pattern: `<chain_prefix>.<dataset_type>`

--- a/skills/datasets/SKILL.md
+++ b/skills/datasets/SKILL.md
@@ -241,10 +241,15 @@ All fields from `solana.transactions` plus:
 | Field | Type | Notes |
 | ----- | ---- | ----- |
 | `id` | string | |
+| `block_slot` | integer | slot number |
+| `block_hash` | string | |
+| `block_timestamp` | timestamp | |
+| `tx_index` | integer | transaction position in block |
+| `signature` | string | transaction signature |
 | `account` | string | account pubkey |
 | `amount_before` | integer | lamports |
 | `amount_after` | integer | lamports |
-| `block_slot` | integer | |
+| `_gs_op` | string | Goldsky internal operation type |
 
 #### `solana.blocks`
 | Field | Type | Notes |

--- a/skills/datasets/data/verified-datasets.json
+++ b/skills/datasets/data/verified-datasets.json
@@ -19,11 +19,14 @@
         "id": "string",
         "sender": "string",
         "recipient": "string",
-        "amount": "string",
-        "address": "string (token contract)",
+        "amount": "decimal",
+        "address": "string (token contract address)",
         "block_number": "integer",
-        "block_timestamp": "integer",
-        "transaction_hash": "string"
+        "block_timestamp": "integer (unix)",
+        "block_hash": "string",
+        "transaction_hash": "string",
+        "transaction_index": "integer",
+        "log_index": "integer"
       }
     },
     "erc721_transfers": {
@@ -38,21 +41,48 @@
         "id": "string",
         "from_address": "string",
         "to_address": "string",
-        "token_id": "string",
-        "address": "string (NFT contract)",
+        "token_id": "decimal",
+        "address": "string (NFT contract address)",
         "block_number": "integer",
-        "block_timestamp": "integer",
-        "transaction_hash": "string"
+        "block_timestamp": "integer (unix)",
+        "block_hash": "string",
+        "transaction_hash": "string",
+        "transaction_index": "integer",
+        "log_index": "integer"
       }
     },
     "raw_transactions": {
-      "description": "Raw transaction data (NOT 'transactions')",
+      "description": "Enriched transaction data including receipt fields (NOT 'transactions')",
       "useCase": "Wallet activity, gas analysis, transaction monitoring",
       "warning": "Use 'raw_transactions' not 'transactions'",
       "chains": {
         "ethereum": { "version": "1.0.0", "startAtSupport": true },
         "base": { "version": "1.0.0", "startAtSupport": true },
         "matic": { "version": "1.0.0", "startAtSupport": true }
+      },
+      "schema": {
+        "id": "string",
+        "hash": "string",
+        "nonce": "integer",
+        "block_hash": "string",
+        "block_number": "integer",
+        "transaction_index": "integer",
+        "from_address": "string",
+        "to_address": "string",
+        "value": "decimal",
+        "gas": "decimal",
+        "gas_price": "decimal",
+        "input": "string (hex)",
+        "max_fee_per_gas": "decimal",
+        "max_priority_fee_per_gas": "decimal",
+        "transaction_type": "integer",
+        "block_timestamp": "integer (unix)",
+        "receipt_cumulative_gas_used": "decimal",
+        "receipt_gas_used": "decimal",
+        "receipt_contract_address": "string | null",
+        "receipt_status": "integer (1=success)",
+        "receipt_effective_gas_price": "decimal",
+        "_note": "L2 chains also include receipt_l1_fee, receipt_l1_gas_used, receipt_l1_gas_price"
       }
     },
     "logs": {
@@ -61,13 +91,37 @@
       "chains": {
         "ethereum": { "version": "1.0.0", "startAtSupport": true },
         "base": { "version": "1.0.0", "startAtSupport": true }
+      },
+      "schema": {
+        "id": "string",
+        "block_number": "integer",
+        "block_hash": "string",
+        "transaction_hash": "string",
+        "transaction_index": "integer",
+        "log_index": "integer",
+        "address": "string (contract address)",
+        "data": "string (hex encoded event data)",
+        "topics": "string (comma-separated hex topic hashes)",
+        "block_timestamp": "integer (unix)"
       }
     },
     "raw_logs": {
-      "description": "Raw event logs (alternative to 'logs')",
-      "useCase": "Same as logs, check availability per chain",
+      "description": "Raw event logs — same schema as logs, check availability per chain",
+      "useCase": "Custom event filtering, contract monitoring",
       "chains": {
         "ethereum": { "version": "1.0.0", "startAtSupport": true }
+      },
+      "schema": {
+        "id": "string",
+        "block_number": "integer",
+        "block_hash": "string",
+        "transaction_hash": "string",
+        "transaction_index": "integer",
+        "log_index": "integer",
+        "address": "string (contract address)",
+        "data": "string (hex encoded event data)",
+        "topics": "string (comma-separated hex topic hashes)",
+        "block_timestamp": "integer (unix)"
       }
     },
     "blocks": {
@@ -76,11 +130,27 @@
       "chains": {
         "ethereum": { "version": "1.0.0", "startAtSupport": true },
         "base": { "version": "1.0.0", "startAtSupport": true }
+      },
+      "schema": {
+        "id": "string",
+        "number": "integer",
+        "hash": "string",
+        "parent_hash": "string",
+        "nonce": "string",
+        "miner": "string",
+        "difficulty": "double",
+        "total_difficulty": "double",
+        "size": "integer",
+        "gas_limit": "integer",
+        "gas_used": "integer",
+        "timestamp": "integer (unix)",
+        "transaction_count": "integer",
+        "base_fee_per_gas": "integer"
       }
     },
     "raw_blocks": {
-      "description": "Raw block data (alternative to 'blocks')",
-      "useCase": "Same as blocks, check availability per chain",
+      "description": "Raw block data — same schema as blocks, check availability per chain",
+      "useCase": "Same as blocks",
       "chains": {
         "ethereum": { "version": "1.0.0", "startAtSupport": true }
       }
@@ -90,6 +160,28 @@
       "useCase": "MEV analysis, contract interactions, deep transaction analysis",
       "chains": {
         "ethereum": { "version": "1.0.0", "startAtSupport": true }
+      },
+      "schema": {
+        "id": "string",
+        "block_number": "integer",
+        "block_hash": "string",
+        "transaction_hash": "string",
+        "transaction_index": "integer",
+        "from_address": "string",
+        "to_address": "string",
+        "value": "decimal",
+        "input": "string",
+        "output": "string",
+        "trace_type": "string",
+        "call_type": "string",
+        "gas": "integer",
+        "gas_used": "integer",
+        "subtraces": "integer",
+        "trace_address": "string",
+        "error": "string | null",
+        "status": "integer",
+        "trace_id": "string",
+        "block_timestamp": "integer (unix)"
       }
     },
     "decoded_logs": {
@@ -106,41 +198,140 @@
       "version": "1.0.0",
       "datasetName": "solana.token_transfers",
       "useCase": "Token tracking on Solana",
-      "note": "Uses start_block (slot number) instead of start_at"
+      "note": "Uses start_block (slot number) instead of start_at",
+      "schema": {
+        "id": "string",
+        "token_mint_address": "string",
+        "from_token_account": "string",
+        "to_token_account": "string",
+        "amount": "number",
+        "decimals": "integer",
+        "block_slot": "integer",
+        "block_timestamp": "timestamp",
+        "signature": "string"
+      }
     },
     "transactions": {
-      "description": "Solana transactions",
+      "description": "Solana transactions with accounts and balances",
       "version": "1.0.0",
-      "datasetName": "solana.transactions"
+      "datasetName": "solana.transactions",
+      "useCase": "Wallet activity, transaction monitoring",
+      "schema": {
+        "id": "string",
+        "index": "integer",
+        "block_slot": "integer",
+        "block_hash": "string",
+        "block_timestamp": "timestamp",
+        "accounts": "string[] (all accounts involved in tx)",
+        "balance_changes": "object[] {account: string, before: integer, after: integer}",
+        "recent_block_hash": "string",
+        "signature": "string",
+        "err": "string | null",
+        "status": "integer (1=success)",
+        "compute_units_consumed": "integer",
+        "fee": "integer (lamports)",
+        "log_messages": "string[]"
+      }
     },
     "transactions_with_instructions": {
-      "description": "Solana transactions with nested instructions",
+      "description": "Solana transactions with nested instructions array",
       "version": "1.0.0",
       "datasetName": "solana.transactions_with_instructions",
-      "useCase": "Multi-instruction analysis, program interaction tracking"
+      "useCase": "Multi-instruction analysis, program interaction tracking",
+      "schema": {
+        "id": "string",
+        "index": "integer",
+        "block_slot": "integer",
+        "block_hash": "string",
+        "block_timestamp": "timestamp",
+        "accounts": "string[] (all accounts involved in tx)",
+        "balance_changes": "object[] {account: string, before: integer, after: integer}",
+        "pre_token_balances": "object[]",
+        "post_token_balances": "object[]",
+        "recent_block_hash": "string",
+        "signature": "string",
+        "err": "string | null",
+        "status": "integer (1=success)",
+        "compute_units_consumed": "integer",
+        "fee": "integer (lamports)",
+        "log_messages": "string[]",
+        "instructions": "object[] {id, index, parent_index, block_slot, block_timestamp, block_hash, tx_fee, tx_index, program_id, data (base58), accounts: string[], status, err}"
+      }
+    },
+    "instructions": {
+      "description": "Individual Solana instructions (one row per instruction)",
+      "version": "1.0.0",
+      "datasetName": "solana.instructions",
+      "useCase": "Program-specific analysis, instruction-level filtering",
+      "schema": {
+        "id": "string",
+        "index": "integer",
+        "parent_index": "integer | null",
+        "block_slot": "integer",
+        "block_timestamp": "timestamp",
+        "block_hash": "string",
+        "program_id": "string",
+        "data": "string (base58 encoded instruction data)",
+        "accounts": "string[]",
+        "status": "integer",
+        "err": "string | null"
+      }
     },
     "blocks": {
-      "description": "Solana block/slot data",
+      "description": "Solana block/slot data with leader info",
       "version": "1.0.0",
-      "datasetName": "solana.blocks"
+      "datasetName": "solana.blocks",
+      "useCase": "Chain analysis, slot timing",
+      "schema": {
+        "id": "string",
+        "slot": "integer",
+        "parent_slot": "integer",
+        "hash": "string",
+        "timestamp": "timestamp",
+        "height": "integer",
+        "previous_block_hash": "string",
+        "transaction_count": "integer",
+        "leader_reward": "integer (lamports)",
+        "leader": "string (validator pubkey)",
+        "skipped": "boolean"
+      }
     },
     "native_balances": {
-      "description": "SOL balance changes",
+      "description": "SOL balance changes per transaction",
       "version": "1.0.0",
       "datasetName": "solana.native_balances",
-      "useCase": "Whale tracking, SOL flow analysis"
+      "useCase": "Whale tracking, SOL flow analysis",
+      "schema": {
+        "id": "string",
+        "account": "string",
+        "amount_before": "integer (lamports)",
+        "amount_after": "integer (lamports)",
+        "block_slot": "integer"
+      }
     },
     "token_balances": {
       "description": "SPL token balance changes",
       "version": "1.0.0",
       "datasetName": "solana.token_balances",
-      "useCase": "Portfolio tracking, token holder analysis"
+      "useCase": "Portfolio tracking, token holder analysis",
+      "schema": "NOT FULLY DOCUMENTED — use 'goldsky dataset list | grep solana.token_balances' to inspect actual fields before writing transforms"
     },
     "rewards": {
-      "description": "Validator rewards",
+      "description": "Validator rewards per block",
       "version": "1.0.0",
       "datasetName": "solana.rewards",
-      "useCase": "Staking analysis, validator performance"
+      "useCase": "Staking analysis, validator performance",
+      "schema": {
+        "id": "string",
+        "block_slot": "integer",
+        "block_hash": "string",
+        "block_timestamp": "timestamp",
+        "commission": "integer",
+        "lamports": "integer",
+        "post_balance": "integer",
+        "pub_key": "string (validator pubkey)",
+        "reward_type": "string"
+      }
     }
   },
   "bitcoin": {

--- a/skills/turbo-architecture/SKILL.md
+++ b/skills/turbo-architecture/SKILL.md
@@ -34,6 +34,8 @@ After the architecture is decided, direct the user to:
 - **`/turbo-transforms`** — To write the SQL transforms
 - **`/secrets`** — To set up sink credentials
 
+**Reminder:** When presenting complete pipeline YAML as part of architecture recommendations, validate it first with `goldsky turbo validate`. Templates in `templates/` are structural patterns — any customized version must be validated before presenting to the user.
+
 ---
 
 ## Source Types

--- a/skills/turbo-builder/SKILL.md
+++ b/skills/turbo-builder/SKILL.md
@@ -117,29 +117,34 @@ Use the `/turbo-architecture` skill to decide:
 - **Streaming** (default) — continuous processing, no `end_block`, runs indefinitely
 - **Job mode** — one-time backfill, set `job: true` and `end_block`
 
-### Step 8: Generate YAML
+### Step 8: Generate, Validate, and Present
 
 Assemble the complete pipeline YAML. Use a descriptive name following the convention: `<chain>-<data>-<sink>` (e.g., `base-erc20-transfers-postgres`).
 
-Write the YAML file to disk (e.g., `<pipeline-name>.yaml`).
+**CLI mode (Bash available):**
 
-Present the full YAML to the user for review before proceeding.
-
-### Step 9: Validate
-
-Run validation:
+1. Write the YAML file to disk (e.g., `<pipeline-name>.yaml`).
+2. Run validation BEFORE showing the YAML to the user:
 
 ```bash
 goldsky turbo validate -f <pipeline-name>.yaml
 ```
 
-If validation fails, fix the issues and re-validate. Common fixes:
-- Missing `version` field on dataset source
-- Invalid dataset name (check chain prefix)
-- Missing `secret_name` for database sinks
-- SQL syntax errors in transforms
+3. If validation fails, fix the issues and re-validate. Do NOT present the YAML until validation passes. Common fixes:
+   - Missing `version` field on dataset source
+   - Invalid dataset name (check chain prefix)
+   - Missing `secret_name` for database sinks
+   - SQL syntax errors in transforms
 
-### Step 10: Deploy
+4. Once validation passes, present the full YAML to the user for review.
+
+**Reference mode (no Bash):**
+
+1. Perform the structural self-check from `turbo-pipelines/references/validation-checklist.md`.
+2. Present the YAML with the checklist results.
+3. Instruct the user to run `goldsky turbo validate -f <file>.yaml` before deploying.
+
+### Step 9: Deploy
 
 After user confirms the YAML looks good:
 
@@ -147,7 +152,7 @@ After user confirms the YAML looks good:
 goldsky turbo apply <pipeline-name>.yaml
 ```
 
-### Step 11: Verify
+### Step 10: Verify
 
 After deployment:
 
@@ -180,6 +185,7 @@ Present a summary:
 
 ## Important Rules
 
+- Always validate before presenting complete YAML to the user. Never show unvalidated complete pipeline YAML.
 - Always validate before deploying.
 - Always show the user the complete YAML before deploying.
 - For job-mode pipelines, remind the user they auto-cleanup ~1hr after completion.

--- a/skills/turbo-pipelines/SKILL.md
+++ b/skills/turbo-pipelines/SKILL.md
@@ -7,7 +7,7 @@ description: "Goldsky Turbo pipeline YAML reference — the authoritative source
 
 YAML configuration reference for Turbo pipelines. This is a lookup reference — for interactive pipeline building, use `/turbo-builder`. For pipeline troubleshooting, use `/turbo-doctor`.
 
-> **CRITICAL:** Always validate YAML with `goldsky turbo validate <file.yaml>` before deploying.
+> **CRITICAL:** Always validate YAML with `goldsky turbo validate <file.yaml>` before showing complete pipeline YAML to the user or deploying.
 
 ---
 
@@ -32,6 +32,10 @@ sinks:
 ```
 
 ```bash
+# Validate first:
+goldsky turbo validate pipeline.yaml
+
+# Then deploy:
 goldsky turbo apply pipeline.yaml -i
 ```
 

--- a/skills/turbo-pipelines/references/validation-checklist.md
+++ b/skills/turbo-pipelines/references/validation-checklist.md
@@ -1,0 +1,65 @@
+# Pipeline YAML Structural Validation Checklist
+
+Use this checklist when `goldsky turbo validate` is not available (no Bash tool). Check every applicable item before presenting complete pipeline YAML to the user.
+
+## Top-Level Structure
+
+- [ ] `name` exists and matches pattern: lowercase letters, numbers, hyphens only
+- [ ] `resource_size` exists and is one of: `s`, `m`, `l`
+- [ ] `sources` section exists and has at least one entry
+- [ ] `sinks` section exists and has at least one entry
+- [ ] If `job: true`, at least one source has `end_block` (or user explicitly wants processing to chain tip)
+
+## Sources
+
+For each source entry:
+
+- [ ] `type` is specified (`dataset` or `kafka`)
+- [ ] For `type: dataset`:
+  - [ ] `dataset_name` follows `<chain>.<dataset_type>` format
+  - [ ] Chain prefix is valid (`matic` not `polygon`, `bsc` not `binance`, `ethereum` not `eth`)
+  - [ ] Dataset type is valid (`raw_transactions` not `transactions`, `raw_logs` not `logs`)
+  - [ ] `version` is specified (e.g., `1.0.0`, `1.2.0`)
+  - [ ] EVM chains: `start_at` is `earliest` or `latest`
+  - [ ] Solana: uses `start_block`, NOT `start_at`
+
+## Transforms
+
+For each transform entry:
+
+- [ ] `type` is one of: `sql`, `script`, `handler`, `dynamic_table`
+- [ ] For `type: sql`:
+  - [ ] `primary_key` is specified
+  - [ ] `sql` field contains a SELECT statement
+  - [ ] All table names in `FROM` / `JOIN` reference a source or earlier transform key
+- [ ] For `type: script`:
+  - [ ] `primary_key`, `language`, `from`, `schema`, and `script` are present
+  - [ ] `schema` field types are valid: `string`, `uint64`, `int64`, `float64`, `boolean`, `bytes`
+- [ ] For `type: dynamic_table`:
+  - [ ] `backend_type` is `Postgres` or `InMemory`
+  - [ ] `backend_entity_name` is specified
+  - [ ] If `backend_type: Postgres`, `secret_name` is specified
+- [ ] For `type: handler`:
+  - [ ] `primary_key`, `from`, and `url` are present
+
+## Sinks
+
+For each sink entry:
+
+- [ ] `type` is one of: `postgres`, `postgres_aggregate`, `clickhouse`, `kafka`, `webhook`, `s3_sink`, `s2_sink`, `blackhole`
+- [ ] `from` references a valid source or transform key name
+- [ ] Required fields by type:
+  - `postgres`: `schema`, `table`, `secret_name`, `primary_key`
+  - `postgres_aggregate`: `schema`, `landing_table`, `agg_table`, `primary_key`, `secret_name`, `group_by`, `aggregate`
+  - `clickhouse`: `table`, `secret_name`, `primary_key`
+  - `kafka`: `topic`
+  - `s3_sink`: `endpoint`, `bucket`, `secret_name`
+  - `s2_sink`: `access_token`, `basin`, `stream`
+  - `webhook`: `url` (no `secret_name`)
+  - `blackhole`: only `from` required
+
+## Cross-References
+
+- [ ] Every sink `from` value matches exactly one source or transform key
+- [ ] Every transform that uses `from` references an existing source or earlier transform
+- [ ] No circular references in transform chains

--- a/skills/turbo-transforms/SKILL.md
+++ b/skills/turbo-transforms/SKILL.md
@@ -7,11 +7,13 @@ description: "Write SQL, TypeScript, and dynamic table transforms for Goldsky Tu
 
 Write, understand, and debug SQL, TypeScript, and dynamic table transforms for Turbo pipeline configurations.
 
-Identify what the user needs (decode, filter, reshape, combine, custom logic, or lookup joins), then use the relevant section below. After writing transforms, always validate the full pipeline YAML:
+Identify what the user needs (decode, filter, reshape, combine, custom logic, or lookup joins), then use the relevant section below. After writing transforms, always validate the full pipeline YAML before presenting it to the user:
 
 ```bash
 goldsky turbo validate <pipeline.yaml>
 ```
+
+If generating a complete pipeline YAML (not just a transform snippet), always validate with `goldsky turbo validate` before presenting it to the user.
 
 **Reference files for specialized topics:**
 - `references/typescript-transforms.md` — TypeScript/WASM script transforms and handler transforms


### PR DESCRIPTION
## Summary

- Adds field-level schemas for all Solana datasets (`transactions`, `transactions_with_instructions`, `instructions`, `token_transfers`, `native_balances`, `blocks`, `rewards`) sourced directly from docs.goldsky.com
- Adds schemas for EVM datasets (`raw_logs`, `logs`, `raw_transactions`, `blocks`, `traces`)
- Corrects existing `erc20_transfers` and `erc721_transfers` schemas (added missing fields, fixed `amount` type `string` → `decimal`)
- Marks `solana.token_balances` as undocumented so the chatbot won't guess field names
- Adds an inline **Dataset Schemas** section to `SKILL.md` with markdown tables — visible in chatbot context without needing to load the JSON file

## Why

The chatbot was hallucinating column names when generating Solana transforms (e.g. using `from_address`/`to_address` which don't exist on `solana.transactions`). All schemas here are sourced from official Goldsky docs, not inferred.

## Test plan

- [ ] Ask chatbot: "write a Solana transform to filter token transfers for a specific mint" → should use `token_mint_address`, `from_token_account`, `to_token_account`
- [ ] Ask chatbot: "write a transform for solana.transactions to get all txs for a wallet" → should use `accounts` array, not `from_address`/`to_address`
- [ ] Ask chatbot about `solana.token_balances` schema → should say it's not documented, not guess

🤖 Generated with [Claude Code](https://claude.com/claude-code)