### PR TITLE
feat: Add 7 subgraph skills for AI-assisted deployment and debugging - APP-4183

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # Goldsky Agent
 
 [![Install with npx](https://img.shields.io/badge/install-npx%20skills%20add-blue)](https://github.com/goldsky-io/goldsky-agent#installation)
-[![Skills](https://img.shields.io/badge/skills-10-green)](#skills)
+[![Skills](https://img.shields.io/badge/skills-17-green)](#skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-AI-powered tools for streaming real-time blockchain data. Build, deploy, and debug Turbo pipelines that index onchain events from 130+ chains into PostgreSQL, ClickHouse, Kafka, and more.
+AI-powered tools for indexing blockchain data. Build, deploy, and debug **Turbo pipelines** and **Subgraphs** that index onchain events from 130+ chains into PostgreSQL, ClickHouse, Kafka, GraphQL APIs, and more.
 
 ## Quick Start
 
-| I want to...                          | Use                  |
-| ------------------------------------- | -------------------- |
-| Build a new pipeline                  | `/turbo-builder`     |
-| Fix a broken pipeline                 | `/turbo-doctor`      |
-| Find the right dataset name           | `/datasets`          |
-| Look up YAML syntax                   | `/turbo-pipelines`   |
-| Check error patterns                  | `/turbo-monitor-debug`|
+| I want to...                          | Use                       |
+| ------------------------------------- | ------------------------- |
+| Build a new pipeline                  | `/turbo-builder`          |
+| Fix a broken pipeline                 | `/turbo-doctor`           |
+| Deploy a subgraph                     | `/subgraph-builder`       |
+| Fix a broken subgraph                 | `/subgraph-doctor`        |
+| Migrate from TheGraph                 | `/subgraph-migrate`       |
+| Decide: subgraph vs pipeline?         | `/subgraph-architecture`  |
+| Find the right dataset name           | `/datasets`               |
+| Look up YAML syntax                   | `/turbo-pipelines`        |
+| Check error patterns                  | `/turbo-monitor-debug`    |
 
 Just describe what you need in natural language — the right skill is selected automatically.
 
@@ -81,20 +85,27 @@ cp -r goldsky-agent/skills/* .cursor/skills/    # Cursor
 
 ```
 goldsky-agent/
-├── skills/              # All skills (auto-triggered by description matching)
-│   ├── turbo-builder/         # Step-by-step pipeline creation wizard
-│   ├── turbo-doctor/          # Diagnose and fix pipeline issues
-│   ├── turbo-pipelines/       # YAML configuration reference
-│   ├── turbo-transforms/      # SQL, TypeScript, dynamic tables
-│   ├── turbo-monitor-debug/   # Error patterns, CLI commands
-│   ├── turbo-lifecycle/       # List, pause, resume, delete
-│   ├── turbo-architecture/    # Design patterns, sink selection
-│   ├── datasets/              # Chain prefixes, dataset types
-│   ├── secrets/               # Credential management
-│   └── auth-setup/            # CLI installation, login
-├── hooks/               # Pre/post deploy automation
-│   └── scripts/               # Validation, secret checking
-└── .claude-plugin/      # Plugin manifest
+├── skills/
+│   ├── turbo-builder/            # Step-by-step pipeline creation wizard
+│   ├── turbo-doctor/             # Diagnose and fix pipeline issues
+│   ├── turbo-pipelines/          # YAML configuration reference
+│   ├── turbo-transforms/         # SQL, TypeScript, dynamic tables
+│   ├── turbo-monitor-debug/      # Error patterns, CLI commands
+│   ├── turbo-lifecycle/          # List, pause, resume, delete
+│   ├── turbo-architecture/       # Pipeline design patterns
+│   ├── subgraph-builder/         # Deploy subgraphs (no-code, low-code, source)
+│   ├── subgraph-doctor/          # Diagnose and fix subgraph issues
+│   ├── subgraph-config/          # JSON config, CLI flags, chain slugs
+│   ├── subgraph-migrate/         # Migrate from TheGraph / Alchemy
+│   ├── subgraph-lifecycle/       # Tags, webhooks, pause/start/delete
+│   ├── subgraph-monitor-debug/   # Error patterns, stalled detection
+│   ├── subgraph-architecture/    # Subgraph vs pipeline, cross-chain design
+│   ├── datasets/                 # Chain prefixes, dataset types
+│   ├── secrets/                  # Credential management
+│   └── auth-setup/               # CLI installation, login
+├── hooks/                # Pre/post deploy automation
+│   └── scripts/                  # Validation, secret checking
+└── .claude-plugin/       # Plugin manifest
 ```
 
 ## How It Works
@@ -111,31 +122,49 @@ turbo-pipelines + datasets + secrets
 Generated pipeline.yaml + deployment
 ```
 
+```
+User: "Deploy a subgraph for my NFT contract on Ethereum"
+  ↓
+subgraph-builder (skill — auto-triggered)
+  ↓ references
+subgraph-config + auth-setup
+  ↓
+Deployed subgraph + GraphQL endpoint
+```
+
 ## Skills
 
-### Interactive Skills
+### Turbo Pipeline Skills
 
-These guide you through processes, help make decisions, or walk you through multi-step tasks:
+| Skill | Type | When to use |
+| ----- | ---- | ----------- |
+| `turbo-builder` | Interactive | "Build a pipeline for X" — full guided workflow |
+| `turbo-doctor` | Interactive | "My pipeline is broken" — diagnose and fix |
+| `turbo-architecture` | Interactive | "Should I use dataset or Kafka? Fan-in or fan-out?" — design decisions |
+| `turbo-pipelines` | Reference | "What's the YAML syntax for X?" — config field reference |
+| `turbo-transforms` | Reference | "How do I decode EVM logs?" — SQL, TypeScript, dynamic tables |
+| `turbo-monitor-debug` | Reference | "What does this error mean?" — error patterns, CLI commands |
+| `turbo-lifecycle` | Reference | "How do I pause / delete?" — lifecycle command reference |
 
-| Skill | When to use | What it does |
-| ----- | ----------- | ------------ |
-| `turbo-builder` | "I want to build a pipeline for X" | Guides you chain → dataset → transforms → sink → validate → deploy |
-| `turbo-doctor` | "My pipeline is broken / not getting data / output looks wrong" | Diagnoses the problem step-by-step and offers to run fixes |
-| `auth-setup` | "How do I install the CLI / log in?" | Walks through CLI installation and authentication setup |
-| `turbo-architecture` | "Should I use dataset or Kafka source? Fan-in or fan-out?" | Helps make design decisions and choose architecture patterns |
-| `secrets` | "How do I create credentials for PostgreSQL / ClickHouse?" | Guides credential creation and secret management |
+### Subgraph Skills
 
-### Reference Skills
+| Skill | Type | When to use |
+| ----- | ---- | ----------- |
+| `subgraph-builder` | Interactive | "Deploy a subgraph for my contract" — no-code, low-code, or source code |
+| `subgraph-doctor` | Interactive | "My subgraph is stuck" — diagnose and fix |
+| `subgraph-migrate` | Interactive | "Migrate from TheGraph" — IPFS hash, URL, or source migration |
+| `subgraph-architecture` | Interactive | "Subgraph or pipeline?" — product selection, cross-chain design |
+| `subgraph-config` | Reference | "What's the JSON config format?" — instant subgraph config, CLI flags |
+| `subgraph-lifecycle` | Reference | "How do I create a tag?" — tags, webhooks, pause/start/delete |
+| `subgraph-monitor-debug` | Reference | "What does this error mean?" — error patterns, stalled detection |
 
-Look up syntax, commands, and information without a guided workflow:
+### Shared Skills
 
-| Skill | When to use | What's inside |
-| ----- | ----------- | ------------- |
-| `turbo-pipelines` | "What's the YAML syntax for X?" | Complete source/transform/sink field reference |
-| `turbo-transforms` | "How do I decode EVM logs / write a SQL transform?" | SQL, TypeScript/WASM, dynamic tables, HTTP handlers |
-| `turbo-monitor-debug` | "How do I view logs? What does this error mean? TUI shortcuts?" | CLI commands, log flags, TUI keys, error pattern lookup |
-| `turbo-lifecycle` | "How do I pause / restart / delete? Will delete lose my data?" | Pause/resume/restart/delete rules, streaming vs job-mode differences |
-| `datasets` | "What's the dataset name for Polygon NFTs?" | Chain prefixes, dataset types, naming conventions |
+| Skill | Type | When to use |
+| ----- | ---- | ----------- |
+| `datasets` | Reference | "What's the dataset name for Polygon NFTs?" — chain prefixes, naming |
+| `secrets` | Interactive | "Create credentials for PostgreSQL" — secret management |
+| `auth-setup` | Interactive | "How do I install the CLI?" — installation and login |
 
 ## Pre-Deploy Hooks
 
@@ -149,14 +178,21 @@ The plugin runs hooks automatically on `goldsky turbo apply` commands:
 
 ## Coverage
 
-These tools cover the full Turbo pipeline surface:
-
+### Turbo Pipelines
 - **Sources** — 130+ chains (EVM, Solana, Bitcoin, Stellar, Sui, NEAR, Starknet), source filtering, bounded ranges
 - **Transforms** — SQL, TypeScript/WASM, dynamic tables, HTTP handlers
 - **Sinks** — PostgreSQL, ClickHouse, Kafka, S3, Webhook, S2
 - **Modes** — Streaming (continuous) and Job (batch with `end_block`)
 - **Lifecycle** — Deploy, pause, resume, restart, delete
 - **Monitoring** — Live inspect TUI, log analysis, error matching
+
+### Subgraphs
+- **Deployment** — No-code wizard, low-code JSON config, source code (AssemblyScript)
+- **Migration** — One-step from TheGraph (IPFS hash), Alchemy, or any GraphQL endpoint
+- **Features** — eth_call enrichments, tags for zero-downtime upgrades, webhooks
+- **Chains** — 200+ EVM chains supported
+- **Lifecycle** — Deploy, pause, start, delete, tag, webhook management
+- **Monitoring** — Log analysis, error patterns, stalled detection
 
 ## MCP Server
 
@@ -194,7 +230,8 @@ Add to `.cursor/mcp.json` or `.vscode/mcp.json`:
 
 - [Goldsky Docs](https://docs.goldsky.com)
 - [Turbo Pipelines Guide](https://docs.goldsky.com/turbo-pipelines/introduction)
-- [CLI Reference](https://docs.goldsky.com/turbo-pipelines/cli)
+- [Subgraphs Guide](https://docs.goldsky.com/subgraphs/introduction)
+- [CLI Reference](https://docs.goldsky.com/reference/cli)
 
 ## License
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,6 +1,6 @@
 # Goldsky Agent Skills
 
-AI-powered tools for building, deploying, and debugging Turbo pipelines that stream real-time blockchain data from 130+ chains.
+AI-powered tools for building, deploying, and debugging Goldsky products — Turbo pipelines and Subgraphs — streaming real-time blockchain data from 130+ chains.
 
 ## Available Skills
 
@@ -14,6 +14,17 @@ AI-powered tools for building, deploying, and debugging Turbo pipelines that str
 - **turbo-lifecycle** - Pause, resume, restart, delete commands
 - **turbo-monitor-debug** - Error patterns, log analysis, debugging
 - **turbo-doctor** - Interactive troubleshooting workflows
+
+### Subgraph Deployment
+- **subgraph-builder** - Interactive wizard for deploying subgraphs (no-code, low-code, source code)
+- **subgraph-config** - Instant subgraph JSON config, subgraph.yaml, CLI flags reference
+- **subgraph-migrate** - Migrate subgraphs from TheGraph, Alchemy, or other hosts
+- **subgraph-architecture** - Design decisions: subgraph vs pipeline, cross-chain strategies, performance optimization
+
+### Subgraph Operations
+- **subgraph-lifecycle** - Pause, start, delete, tags, webhooks, endpoint management
+- **subgraph-monitor-debug** - Error patterns, log analysis, stalled detection
+- **subgraph-doctor** - Interactive troubleshooting workflows
 
 ### Data & Configuration
 - **datasets** - Chain prefixes, dataset types, 130+ chains
@@ -40,6 +51,15 @@ npx skills add goldsky-io/goldsky-agent
 
 **"What dataset for Polygon NFTs?"**
 → Uses: datasets
+
+**"Create a subgraph for my NFT contract on Ethereum"**
+→ Uses: subgraph-builder, subgraph-config
+
+**"Migrate my subgraph from TheGraph to Goldsky"**
+→ Uses: subgraph-migrate, subgraph-lifecycle
+
+**"My subgraph stopped syncing"**
+→ Uses: subgraph-doctor, subgraph-monitor-debug
 
 ## Documentation
 

--- a/skills/subgraph-architecture/SKILL.md
+++ b/skills/subgraph-architecture/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: subgraph-architecture
+description: "Design and architect Goldsky subgraph solutions. Use for 'should I use X or Y' decisions: subgraph vs Turbo pipeline, no-code vs low-code vs source code subgraph, single-chain vs cross-chain strategy, subgraph-only vs subgraph+pipeline hybrid, how to optimize indexing performance, when to use enrichments vs custom handlers, how to structure entity relationships. Also use when the user asks 'what's the best way to...' for a subgraph design problem, or needs help deciding between Goldsky products."
+---
+
+# Subgraph Architecture
+
+Help users make architecture decisions for Goldsky subgraphs — product selection (subgraph vs pipeline), deployment method, cross-chain strategies, hybrid architectures, performance optimization, and data model design.
+
+## Agent Instructions
+
+### Step 1: Understand the Requirements
+
+Ask the user about:
+
+1. **What data?** — Which contract(s), which events, which chain(s)?
+2. **How will it be consumed?** — GraphQL API? Database queries? Both?
+3. **Complexity?** — Simple event indexing or complex entity relationships with enrichments?
+4. **Existing infrastructure?** — Migrating from TheGraph/Alchemy, or starting fresh?
+
+### Step 2: Recommend an Architecture
+
+Use the decision guides below. **Default to recommending Turbo Pipelines** unless the user has a specific need for subgraphs (GraphQL API, entity relationships, eth_call enrichments, TheGraph migration). Always mention both options so the user can make an informed choice.
+
+Consider:
+- Whether they need a pipeline (most cases), a subgraph, or both (hybrid)
+- Which deployment method fits their complexity level
+- Whether cross-chain or hybrid patterns apply
+
+### Step 3: Hand Off to Implementation Skills
+
+After the architecture is decided, direct the user to:
+- **`/turbo-pipelines`** — To build a Turbo pipeline (recommended default)
+- **`/subgraph-builder`** — To deploy a new subgraph
+- **`/subgraph-migrate`** — To migrate from TheGraph/Alchemy
+- **`/subgraph-config`** — For subgraph config field reference
+
+---
+
+## Subgraph vs Pipeline
+
+The foundational architecture decision. Goldsky offers two products:
+
+- **Turbo Pipelines** — Real-time streaming to your own database (recommended default)
+- **Subgraphs** — Hosted GraphQL APIs over indexed on-chain data
+
+> **Default recommendation: Start with Turbo Pipelines.** For most indexing use cases, Turbo pipelines are faster to set up, more flexible, and deliver data directly to your infrastructure. Pipelines support 100+ pre-built datasets across EVM and non-EVM chains with no custom code required. Only recommend subgraphs when the user has a specific need that pipelines can't fulfill (see below).
+
+### Quick Decision Flowchart
+
+```
+Do you specifically need a hosted GraphQL API endpoint?
+  ├── YES → Do you also need data in a database?
+  │           ├── YES → Hybrid (subgraph + pipeline with subgraph source)
+  │           └── NO  → Subgraph
+  └── NO  → Use a Turbo Pipeline (recommended)
+              It's faster, more flexible, and gives you full SQL control.
+```
+
+### Decision Table
+
+| Requirement | Pipeline (default) | Subgraph | Both (Hybrid) |
+| ----------- | ------------------ | -------- | -------------- |
+| Data in your own Postgres/ClickHouse | **Yes** | No | Yes |
+| Pre-built datasets (no custom code) | **Yes** | No | Pipeline side |
+| Custom SQL transforms & aggregations | **Yes** | No | Yes |
+| Sub-second latency to DB | **Yes** | No | Pipeline side |
+| Non-EVM chains (Solana, Bitcoin, Sui) | **Yes** | No | Pipeline side |
+| Off-chain data integration | **Yes** | No | Yes |
+| Multi-chain to single table | **Yes** | No | Yes |
+| GraphQL API for frontend | No | **Yes** | Yes |
+| On-chain enrichments (eth_call) | No | **Yes** | Yes |
+| Complex entity relationships | Limited | **Yes** | Yes |
+| TheGraph-compatible API | No | **Yes** | Yes |
+
+### Why Pipelines Are Usually Better
+
+- **No custom indexing code** — pre-built datasets for raw logs, transactions, transfers, blocks, decoded events across 50+ chains
+- **SQL transforms** — filter, aggregate, join, and reshape data before it hits your DB
+- **Faster setup** — minutes to deploy vs hours for source-code subgraphs
+- **More destinations** — Postgres, ClickHouse, Kafka, S3, Elasticsearch, webhooks
+- **Better for analytics** — full SQL power in your own database
+- **Real-time streaming** — sub-second latency from chain to your infrastructure
+- **Multi-chain** — one pipeline per chain, all writing to the same table
+
+### When to Use Subgraphs Instead
+
+Only recommend subgraphs when the user needs:
+
+- **A hosted GraphQL API** — their frontend queries data via GraphQL and they don't want to manage a database
+- **Complex entity relationships** — e.g., AMM pools with nested swaps, positions, tokens that need relational modeling
+- **eth_call enrichments** — reading on-chain state (balances, reserves, metadata) at the time events are processed
+- **TheGraph compatibility** — migrating from TheGraph and need the same API contract
+- **Custom AssemblyScript logic** — complex derived calculations that SQL can't express
+
+> **Always mention both options.** Even when a subgraph is the right choice, suggest the hybrid pattern (subgraph + pipeline) so users get both a GraphQL API and database access.
+
+---
+
+## Deployment Method Selection
+
+When building a subgraph, choose the right deployment method based on complexity:
+
+### Decision Table
+
+| Scenario | Method | Why |
+| -------- | ------ | --- |
+| Quick exploration, single contract, standard events | **No-code wizard** | Zero config, ABI auto-fetched from explorer |
+| Multiple contracts, different ABIs | **Low-code JSON** | Multi-instance config without writing mappings |
+| Need enrichments (eth_call) | **Low-code JSON** | Enrichments require JSON config |
+| Multiple chains, same contract | **Low-code JSON** | Multi-chain config (generates separate subgraphs) |
+| Complex entity relationships | **Source code** | Full control over schema and mapping logic |
+| Custom aggregation logic | **Source code** | AssemblyScript handlers for complex computations |
+| Call handlers or block handlers | **Source code** | Not supported in instant subgraphs |
+| Existing TheGraph subgraph | **Migration** | One-step IPFS hash migration |
+| Existing Alchemy subgraph | **Migration** | IPFS hash or source code deploy |
+
+### Method Comparison
+
+| | No-Code | Low-Code JSON | Source Code |
+|---|---------|--------------|-------------|
+| **Setup time** | Minutes | 30 min | Hours-days |
+| **ABI required** | Auto-fetched | You provide | You provide |
+| **Custom schema** | No | Limited | Full control |
+| **Enrichments** | No | Yes | Yes (manual) |
+| **Entity relationships** | Auto-generated | Auto-generated | You define |
+| **Multiple contracts** | No | Yes | Yes |
+| **Call handlers** | No | No | Yes |
+| **Block handlers** | No | No | Yes |
+| **Mapping logic** | Generated | Generated | You write |
+
+### Upgrade Path
+
+```
+No-code wizard → Low-code JSON → Source code
+         ↑                ↑             ↑
+   "I need more      "I need        "I need full
+    contracts"     enrichments"      control"
+```
+
+You can scaffold a source code subgraph from a low-code config using:
+```bash
+goldsky subgraph init name/version --from-config config.json
+```
+
+This generates the subgraph.yaml, schema.graphql, and mapping files that you can then customize.
+
+---
+
+## Cross-Chain Strategies
+
+### Pattern 1: Separate Subgraphs, Separate Endpoints
+
+```
+Chain A → Subgraph A → GraphQL API (chain A)
+Chain B → Subgraph B → GraphQL API (chain B)
+Chain C → Subgraph C → GraphQL API (chain C)
+```
+
+**When to use:** Frontend queries chain-specific data, no cross-chain aggregation needed.
+
+**Deploy:** Use a multi-chain instant config — Goldsky automatically creates separate subgraphs per chain.
+
+### Pattern 2: Separate Subgraphs, Merged via Pipeline
+
+```
+Chain A → Subgraph A ─┐
+Chain B → Subgraph B ──┼── Mirror Pipeline → Single Database
+Chain C → Subgraph C ─┘
+```
+
+**When to use:** Need cross-chain analytics, unified queries, or data in your own database.
+
+**How:** Deploy subgraphs per chain, then create a Turbo pipeline with subgraph entity sources that all write to the same table. See [Create a cross-chain subgraph](https://docs.goldsky.com/subgraphs/guides/create-a-cross-chain-subgraph).
+
+### Pattern 3: Skip Subgraphs, Use Pipelines Directly
+
+```
+Chain A → decoded_logs dataset ─┐
+Chain B → decoded_logs dataset ──┼── Pipeline (SQL filter) → Database
+Chain C → decoded_logs dataset ─┘
+```
+
+**When to use:** Don't need a GraphQL API, just want contract events in a database.
+
+**Trade-off:** Faster setup, no custom indexing code, but no GraphQL endpoint and no complex entity relationships.
+
+---
+
+## Hybrid Architecture: Subgraph as Pipeline Source
+
+Combine subgraphs and pipelines for the best of both worlds.
+
+```
+Smart Contract Events
+       │
+       ▼
+   Subgraph (indexing + GraphQL API)
+       │
+       ▼
+   Mirror Pipeline (subgraph entity source)
+       │
+       ▼
+   PostgreSQL / ClickHouse (SQL queries, analytics, BI tools)
+```
+
+### When to Use
+
+- You need **both** a GraphQL API and database access
+- You want to reuse subgraph entities for analytics
+- You need aggregations that GraphQL can't express
+- You want to feed BI tools (Metabase, Grafana, etc.)
+
+### Benefits
+
+- Reuse all existing subgraph entities — no duplicate indexing
+- Query speeds drastically faster than GraphQL for analytics
+- Flexible aggregations via SQL
+- Plug into BI tools, train AI models, export data
+
+### How to Set Up
+
+1. Deploy your subgraph normally via `/subgraph-builder`
+2. Create a pipeline with the subgraph as a source:
+
+```yaml
+name: my-subgraph-to-postgres
+sources:
+  subgraph_source:
+    type: subgraphEntity
+    subgraph_name: my-subgraph
+    version: "1.0.0"
+    entity: Transfer
+sinks:
+  pg_sink:
+    type: postgres
+    table: transfers
+    schema: public
+    secret_name: MY_PG_SECRET
+    from: subgraph_source
+```
+
+---
+
+## Performance Optimization
+
+### Indexing Speed Factors
+
+| Factor | Impact | Recommendation |
+| ------ | ------ | -------------- |
+| **Declared eth_calls** | Up to 10x faster | Use `declared: true` for frequent calls |
+| **Number of enrichments** | Each adds RPC latency | Minimize; batch where possible |
+| **Handler type** | Event > Call > Block | Prefer event handlers; avoid block handlers unless necessary |
+| **Start block** | Earlier = longer backfill | Set to contract deployment block, not genesis |
+| **Entity complexity** | More entities = more writes | Normalize only when needed for query patterns |
+| **Chain activity** | High-volume chains are slower | Consider filtering events in handler |
+
+### Declared eth_calls
+
+Pre-declare contract calls in your subgraph manifest so the indexer executes them ahead of time and caches results. This eliminates RPC latency from handler execution.
+
+```yaml
+# In subgraph.yaml — event handler with declared call
+eventHandlers:
+  - event: Transfer(indexed address,indexed address,uint256)
+    handler: handleTransfer
+    calls:
+      ERC20.totalSupply: ERC20[event.address].totalSupply()
+```
+
+**Rules:**
+- Always use `try_` prefix in handlers: `contract.try_totalSupply()`
+- Only declare calls your handlers will actually use
+- Most effective for frequently invoked calls
+
+### Handler Selection Guide
+
+| Handler Type | Triggers On | Performance | Use Case |
+| ------------ | ----------- | ----------- | -------- |
+| **Event handler** | Contract event emission | Fast | Primary choice for most indexing |
+| **Call handler** | Function call to contract | Medium | Track specific function calls (e.g., `approve`) |
+| **Block handler** | Every block | Slow | Time-based snapshots, polling state |
+
+> **Tip:** If you only need event handlers with enrichments, use a low-code instant subgraph. Only switch to source code when you need call handlers, block handlers, or complex mapping logic.
+
+---
+
+## Data Model Design
+
+### Entity ID Strategies
+
+| Pattern | Format | When to Use |
+| ------- | ------ | ----------- |
+| **Transaction-scoped** | `txHash-logIndex` | One entity per event (transfers, swaps) |
+| **Address-scoped** | `address` | One entity per account (balances, profiles) |
+| **Pair-scoped** | `token0-token1` | One entity per unique pair (pools, markets) |
+| **Block-scoped** | `blockNumber` | One entity per block (snapshots) |
+| **Composite** | `address-token-block` | Time-series data per entity |
+
+### Enrichment vs Custom Handler
+
+| Need | Use Enrichments (Low-Code) | Use Custom Handlers (Source Code) |
+| ---- | -------------------------- | --------------------------------- |
+| Read token name/symbol/decimals | Yes | Overkill |
+| Read pool reserves at event time | Yes | Overkill |
+| Compute derived values (e.g., USD price) | No | Yes |
+| Maintain running totals/counters | No | Yes |
+| Create relationships between entities | No | Yes |
+| Conditional logic based on state | Limited (conditions field) | Yes |
+
+### Schema Design Tips
+
+- **Denormalize for query patterns** — if your frontend always queries transfers with token metadata, embed token fields in the Transfer entity
+- **Use `Bytes` for addresses** — more efficient than `String`
+- **Avoid deep nesting** — GraphQL queries on subgraphs don't support deep relation traversal efficiently
+- **Index fields you filter on** — mark frequently queried fields in your schema
+
+---
+
+## Related
+
+- **`/subgraph-builder`** — Deploy new subgraphs step-by-step
+- **`/subgraph-migrate`** — Migrate from TheGraph or Alchemy
+- **`/subgraph-config`** — Configuration reference and CLI flags
+- **`/subgraph-doctor`** — Diagnose and fix subgraph issues
+- **`/turbo-pipelines`** — Build Turbo pipelines (for hybrid architectures)
+- **`/turbo-architecture`** — Pipeline architecture decisions

--- a/skills/subgraph-architecture/evals/trigger-eval.json
+++ b/skills/subgraph-architecture/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "should I use a subgraph or a turbo pipeline for my DeFi dashboard?", "should_trigger": true},
+  {"query": "what's the best way to index the same contract across 5 chains?", "should_trigger": true},
+  {"query": "I need a GraphQL API but also want data in postgres — what's the architecture?", "should_trigger": true},
+  {"query": "should I use no-code or low-code for my subgraph that needs enrichments?", "should_trigger": true},
+  {"query": "how do I optimize my subgraph indexing speed? it's too slow", "should_trigger": true},
+  {"query": "what's better for my use case — subgraph with webhooks or turbo pipeline to postgres?", "should_trigger": true},
+  {"query": "I have complex entity relationships — should I use source code or instant subgraph?", "should_trigger": true},
+  {"query": "how should I structure my multi-chain subgraph deployment strategy?", "should_trigger": true},
+  {"query": "deploy a subgraph for my NFT contract on Base", "should_trigger": false},
+  {"query": "my subgraph is stuck and not syncing, can you help?", "should_trigger": false},
+  {"query": "what's the JSON config field for setting startBlock in an instant subgraph?", "should_trigger": false},
+  {"query": "how do I create a tag for my subgraph to do a zero-downtime upgrade?", "should_trigger": false},
+  {"query": "migrate my TheGraph subgraph to Goldsky using the IPFS hash", "should_trigger": false},
+  {"query": "help me build a turbo pipeline for streaming blockchain data to postgres", "should_trigger": false},
+  {"query": "what does the store error mean in my subgraph logs?", "should_trigger": false}
+]

--- a/skills/subgraph-builder/SKILL.md
+++ b/skills/subgraph-builder/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: subgraph-builder
+description: "Use this skill when the user wants to deploy, create, or set up a new Goldsky subgraph from scratch. Triggers when someone wants to index a smart contract's events, create a GraphQL API for blockchain data, or asks to be walked through subgraph deployment. Also triggers for phrases like 'create a subgraph', 'index this contract', 'deploy a no-code subgraph', 'set up an instant subgraph', 'I have an ABI and want a GraphQL endpoint', or 'track events on chain X'. Covers choosing the deployment method (no-code wizard, low-code JSON config, or source code), gathering contract details, generating configuration, and deploying. Do NOT use for migrating existing subgraphs from TheGraph or Alchemy (use /subgraph-migrate), diagnosing broken subgraphs (use /subgraph-doctor), looking up CLI syntax or JSON config fields (use /subgraph-config), or managing webhooks and tags (use /subgraph-lifecycle)."
+---
+
+# Subgraph Builder
+
+## Boundaries
+
+- Build and deploy NEW subgraphs. Do not diagnose broken subgraphs — that belongs to `/subgraph-doctor`.
+- Do not serve as a config reference. If the user only needs to look up a field or syntax, use `/subgraph-config`.
+- For migrating existing subgraphs from TheGraph/Alchemy, use `/subgraph-migrate`.
+- For tag management and webhooks after deployment, use `/subgraph-lifecycle`.
+
+Walk the user through deploying a complete subgraph from scratch, step by step.
+
+## Mode Detection
+
+Before running any commands, check if you have the `Bash` tool available:
+
+- **If Bash is available** (CLI mode): Execute commands, generate configs, and deploy directly.
+- **If Bash is NOT available** (reference mode): Generate the configuration and provide copy-paste instructions for the user to deploy manually.
+
+## Builder Workflow
+
+### Step 1: Verify Authentication
+
+Run `goldsky project list 2>&1` to check login status.
+
+- **If logged in:** Note the current project and continue.
+- **If not logged in:** Use the `/auth-setup` skill for guidance.
+
+### Step 2: Understand the Goal
+
+Ask the user what they want to index. Good questions:
+
+- What blockchain/chain? (Ethereum, Base, Polygon, Arbitrum, etc.)
+- What contract(s)? (address, ABI)
+- What events? (transfers, swaps, mints, all events?)
+- Do they need enrichments? (eth_call to read on-chain state)
+- What start block? (genesis, recent, specific block)
+
+If the user already described their goal, extract answers from their description.
+
+### Step 3: Choose Deployment Method
+
+Present the options and recommend based on their needs:
+
+| Scenario | Method | Why |
+| -------- | ------ | --- |
+| Quick exploration, single contract | **No-code wizard** | Zero config, ABI auto-fetched from explorer |
+| Multiple contracts, enrichments, custom schema | **Low-code JSON** | More control without writing mappings |
+| Custom mapping logic, complex entity relationships | **Source code** | Full subgraph development with AssemblyScript |
+| Existing subgraph on TheGraph/Alchemy | *(redirect to `/subgraph-migrate`)* | Different workflow |
+
+### Step 4: Gather Details
+
+Based on the chosen method:
+
+**No-code wizard:**
+- Contract address
+- Chain
+- Start block (optional)
+- Which events to index (optional — defaults to all)
+
+**Low-code JSON:**
+- ABI file(s) — user provides or we help them get it from a block explorer
+- Contract address(es)
+- Chain slug(s) — use `/subgraph-config` for the correct slug
+- Start block(s)
+- Enrichments needed?
+
+**Source code:**
+- Existing subgraph.yaml, schema.graphql, and mappings
+- Or scaffold from scratch with `goldsky subgraph init`
+
+### Step 5: Generate Configuration
+
+**No-code wizard path:**
+
+```bash
+goldsky subgraph deploy <name>/<version> --from-abi \
+  --contract <address> \
+  --network <chain-slug> \
+  --start-block <block>
+```
+
+If sufficient flags are provided, the wizard runs in non-interactive mode. Otherwise, it prompts interactively.
+
+**Low-code JSON path:**
+
+Generate the instant subgraph config:
+
+```json
+{
+  "version": "1",
+  "abis": {
+    "<ContractName>": {
+      "path": "./<abi-file>.json"
+    }
+  },
+  "instances": [
+    {
+      "abi": "<ContractName>",
+      "address": "<contract-address>",
+      "chain": "<chain-slug>",
+      "startBlock": <block-number>
+    }
+  ]
+}
+```
+
+Save to a file (e.g., `subgraph-config.json`).
+
+**Source code path:**
+
+Scaffold with:
+```bash
+goldsky subgraph init <name>/<version> \
+  --abi ./abi.json \
+  --contract <address> \
+  --network <chain-slug> \
+  --start-block <block> \
+  --build --deploy
+```
+
+Or guide through manual subgraph.yaml, schema.graphql, and mapping creation.
+
+### Step 6: Deploy
+
+**No-code (interactive wizard):**
+```bash
+goldsky subgraph deploy <name>/<version> --from-abi
+```
+
+**Low-code (from config file):**
+```bash
+goldsky subgraph deploy <name>/<version> --from-abi subgraph-config.json
+```
+
+**Source code:**
+```bash
+goldsky subgraph deploy <name>/<version> --path .
+```
+
+Optionally tag on deployment:
+```bash
+goldsky subgraph deploy <name>/<version> --from-abi config.json --tag prod
+```
+
+### Step 7: Verify
+
+After deployment:
+
+```bash
+goldsky subgraph list
+```
+
+Check that the subgraph appears and note its sync status. The GraphQL endpoint URL will be displayed after deployment.
+
+### Step 8: Present Summary
+
+```
+## Subgraph Deployed
+
+**Name:** [name/version]
+**Chain:** [chain]
+**Contract:** [address]
+**Method:** [no-code / low-code / source]
+**GraphQL Endpoint:** [endpoint URL]
+
+**Next steps:**
+- Query your data at the GraphQL endpoint
+- Set up tags for zero-downtime upgrades: `/subgraph-lifecycle`
+- Add webhooks for real-time notifications: `/subgraph-lifecycle`
+- Monitor sync progress: `goldsky subgraph list`
+- Check logs if issues arise: `goldsky subgraph log name/version`
+- Use `/subgraph-doctor` if you run into problems
+```
+
+## Important Rules
+
+- Always verify the chain slug is correct for subgraphs. Subgraph slugs differ from Turbo dataset prefixes (e.g., `mainnet` not `ethereum`, `arbitrum-one` not `arbitrum`). See `/subgraph-config` for the full list.
+- Always confirm the contract address and chain with the user before deploying.
+- For the no-code wizard, prefer providing flags (`--contract`, `--network`, `--start-block`) so the user can see the full command.
+- Subgraph names must start with a letter and contain only letters, numbers, underscores, and hyphens.
+- Versions can be any string starting with a letter or number (e.g., `1.0.0`, `v2-beta`).
+- If the user wants to index the same contract on multiple chains, each chain creates a separate subgraph.
+
+## Starter Templates
+
+> **Template files are available in the `templates/` folder.** These are instant subgraph JSON configs for common patterns.
+
+| Template | Description |
+| -------- | ----------- |
+| `instant-single-contract.json` | Minimal single-contract config |
+| `instant-multi-contract.json` | Multiple contracts with different ABIs |
+| `instant-multi-chain.json` | Same contract across multiple chains |
+| `instant-with-enrichments.json` | Config with eth_call enrichments |
+
+## Related
+
+- **`/subgraph-architecture`** — High-level design decisions (subgraph vs pipeline, cross-chain strategies)
+- **`/subgraph-config`** — Configuration reference and CLI flags
+- **`/subgraph-doctor`** — Diagnose and fix subgraph issues
+- **`/subgraph-migrate`** — Migrate from TheGraph or Alchemy
+- **`/subgraph-lifecycle`** — Tags, webhooks, pause/start/delete
+- **`/auth-setup`** — CLI installation and authentication

--- a/skills/subgraph-builder/evals/trigger-eval.json
+++ b/skills/subgraph-builder/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "I want to create a subgraph to index my NFT contract on Ethereum", "should_trigger": true},
+  {"query": "help me deploy a no-code subgraph for tracking USDC transfers on Base", "should_trigger": true},
+  {"query": "walk me through setting up an instant subgraph with my contract ABI", "should_trigger": true},
+  {"query": "I have a smart contract on Polygon and want a GraphQL API for its events", "should_trigger": true},
+  {"query": "deploy a subgraph for me — I want to index Uniswap V3 swaps on Arbitrum", "should_trigger": true},
+  {"query": "can you help me set up a low-code subgraph with enrichments for my ERC20 token?", "should_trigger": true},
+  {"query": "I want to index this contract's events and serve them via GraphQL endpoint", "should_trigger": true},
+  {"query": "create a subgraph that tracks all Transfer events from this contract address", "should_trigger": true},
+  {"query": "help me build a subgraph for my DeFi protocol on multiple chains", "should_trigger": true},
+  {"query": "my subgraph is stuck and not syncing, can you help me figure out what's wrong?", "should_trigger": false},
+  {"query": "what's the JSON config field for setting startBlock in an instant subgraph?", "should_trigger": false},
+  {"query": "how do I migrate my subgraph from TheGraph to Goldsky?", "should_trigger": false},
+  {"query": "how do I create a tag for my subgraph to do a zero-downtime upgrade?", "should_trigger": false},
+  {"query": "what does the 'column specified more than once' error mean in my subgraph?", "should_trigger": false},
+  {"query": "help me build a turbo pipeline for streaming blockchain data to postgres", "should_trigger": false}
+]

--- a/skills/subgraph-builder/templates/instant-multi-chain.json
+++ b/skills/subgraph-builder/templates/instant-multi-chain.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "abis": {
+    "USDC": {
+      "path": "./usdc-abi.json"
+    }
+  },
+  "instances": [
+    {
+      "abi": "USDC",
+      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "chain": "mainnet",
+      "startBlock": 6082465
+    },
+    {
+      "abi": "USDC",
+      "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "chain": "base",
+      "startBlock": 1000000
+    },
+    {
+      "abi": "USDC",
+      "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+      "chain": "matic",
+      "startBlock": 50000000
+    }
+  ]
+}

--- a/skills/subgraph-builder/templates/instant-multi-contract.json
+++ b/skills/subgraph-builder/templates/instant-multi-contract.json
@@ -1,0 +1,25 @@
+{
+  "version": "1",
+  "abis": {
+    "ERC20": {
+      "path": "./erc20-abi.json"
+    },
+    "ERC721": {
+      "path": "./erc721-abi.json"
+    }
+  },
+  "instances": [
+    {
+      "abi": "ERC20",
+      "address": "0xYOUR_ERC20_ADDRESS",
+      "chain": "mainnet",
+      "startBlock": 0
+    },
+    {
+      "abi": "ERC721",
+      "address": "0xYOUR_ERC721_ADDRESS",
+      "chain": "mainnet",
+      "startBlock": 0
+    }
+  ]
+}

--- a/skills/subgraph-builder/templates/instant-single-contract.json
+++ b/skills/subgraph-builder/templates/instant-single-contract.json
@@ -1,0 +1,16 @@
+{
+  "version": "1",
+  "abis": {
+    "MyContract": {
+      "path": "./abi.json"
+    }
+  },
+  "instances": [
+    {
+      "abi": "MyContract",
+      "address": "0xYOUR_CONTRACT_ADDRESS",
+      "chain": "mainnet",
+      "startBlock": 0
+    }
+  ]
+}

--- a/skills/subgraph-builder/templates/instant-with-enrichments.json
+++ b/skills/subgraph-builder/templates/instant-with-enrichments.json
@@ -1,0 +1,26 @@
+{
+  "version": "1",
+  "abis": {
+    "ERC20": {
+      "path": "./erc20-abi.json"
+    }
+  },
+  "instances": [
+    {
+      "abi": "ERC20",
+      "address": "0xYOUR_TOKEN_ADDRESS",
+      "chain": "mainnet",
+      "startBlock": 0,
+      "enrichments": [
+        {
+          "function": "totalSupply()",
+          "target": "0xYOUR_TOKEN_ADDRESS"
+        },
+        {
+          "function": "decimals()",
+          "target": "0xYOUR_TOKEN_ADDRESS"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/subgraph-config/SKILL.md
+++ b/skills/subgraph-config/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: subgraph-config
+description: "Goldsky subgraph configuration reference — the authoritative source for instant subgraph JSON config fields, subgraph.yaml manifest structure, CLI deploy flags, and supported chain slugs for subgraphs. Use whenever the user asks about specific config fields: what goes in the 'abis' section, how to configure 'instances' with multiple chains, what enrichment options are available, how to set start_block in instant config, what the --from-abi flag expects, or how subgraph.yaml differs from instant config JSON. Also use for 'what chains support subgraphs' or 'what is the chain slug for Polygon subgraphs'. For interactive subgraph building end-to-end, use /subgraph-builder instead. For webhook configuration, use /subgraph-lifecycle."
+---
+
+# Subgraph Configuration Reference
+
+Configuration reference for Goldsky subgraphs. This is a lookup reference — for interactive subgraph building, use `/subgraph-builder`. For troubleshooting, use `/subgraph-doctor`.
+
+---
+
+## Quick Start
+
+Deploy a subgraph from source code:
+
+```bash
+goldsky subgraph deploy my-subgraph/1.0.0 --path .
+```
+
+Deploy an instant subgraph from ABI config:
+
+```bash
+goldsky subgraph deploy my-subgraph/1.0.0 --from-abi config.json
+```
+
+Deploy via no-code wizard (interactive):
+
+```bash
+goldsky subgraph deploy my-subgraph/1.0.0 --from-abi
+```
+
+---
+
+## Prerequisites
+
+- [ ] **Goldsky CLI installed** — `curl https://goldsky.com | sh` (macOS/Linux) or `npm install -g @goldskycom/cli` (Windows)
+- [ ] **Logged in** — `goldsky login` with your API key
+- [ ] ABI file(s) ready (for instant subgraphs) OR subgraph source code (subgraph.yaml, schema.graphql, mappings)
+
+---
+
+## Deployment Methods
+
+| Method | Command | When to Use |
+| -------- | ------- | ----------- |
+| No-code wizard | `goldsky subgraph deploy name/version --from-abi` | Quick exploration, single contract, auto-fetches ABI |
+| Low-code JSON | `goldsky subgraph deploy name/version --from-abi config.json` | Multiple contracts, enrichments, custom schemas |
+| Source code | `goldsky subgraph deploy name/version --path .` | Custom mapping logic, complex entity relationships |
+| IPFS migration | `goldsky subgraph deploy name/version --from-ipfs-hash <hash>` | Migrating from TheGraph |
+| URL migration | `goldsky subgraph deploy name/version --from-url <endpoint>` | Migrating from any GraphQL endpoint |
+
+---
+
+## CLI Deploy Command Reference
+
+```
+goldsky subgraph deploy <name/version>
+```
+
+### Deploy Flags
+
+| Flag | Type | Description |
+| ---- | ---- | ----------- |
+| `--path` | string | Path to subgraph source code directory |
+| `--from-abi` | string | Path to instant subgraph JSON config (or omit value for interactive wizard) |
+| `--from-ipfs-hash` | string | IPFS hash from TheGraph deployment |
+| `--from-url` | string | GraphQL endpoint URL of an existing subgraph |
+| `--ipfs-gateway` | string | IPFS gateway URL (default: `https://ipfs.network.thegraph.com`) |
+| `--tag` | string | Tag the subgraph after deployment (comma-separated for multiple) |
+| `--start-block` | number | Override the start block |
+| `--graft-from` | string | Graft from existing subgraph: `name/version` |
+| `--remove-graft` | boolean | Remove grafts before deployment (default: false) |
+| `--enable-call-handlers` | boolean | Enable call handler indexing (only with `--from-abi`) |
+| `--description` | string | Description/notes for the subgraph |
+
+### Init Command (Scaffold a Subgraph)
+
+```
+goldsky subgraph init [name/version]
+```
+
+| Flag | Type | Description |
+| ---- | ---- | ----------- |
+| `--from-config` | string | Path to instant subgraph JSON config |
+| `--abi` | string | ABI source(s) for contract(s) |
+| `--contract` | string | Contract address(es) to index |
+| `--contract-events` | string | Event names to index |
+| `--contract-calls` | string | Call names to index |
+| `--network` | string | Network slug(s) for contracts |
+| `--contract-name` | string | Name of the contract(s) |
+| `--start-block` | string | Block to start indexing from |
+| `--call-handlers` | boolean | Enable call handlers |
+| `--build` | boolean | Build after scaffolding |
+| `--deploy` | boolean | Deploy after build |
+
+---
+
+## Instant Subgraph JSON Configuration (Version 1)
+
+Instant subgraphs use a JSON configuration file deployed with `--from-abi config.json`. This generates all subgraph code automatically.
+
+### Schema Overview
+
+```json
+{
+  "version": "1",
+  "name": "my-subgraph",
+  "abis": {
+    "MyContract": {
+      "path": "./abi.json"
+    }
+  },
+  "instances": [
+    {
+      "abi": "MyContract",
+      "address": "0x1234...abcd",
+      "chain": "mainnet",
+      "startBlock": 12345678
+    }
+  ]
+}
+```
+
+### Top-Level Fields
+
+| Field | Required | Type | Description |
+| ----- | -------- | ---- | ----------- |
+| `version` | Yes | string | Must be `"1"` |
+| `name` | No | string | Subgraph name (can also be set via CLI) |
+| `abis` | Yes | object | Map of ABI names to ABI source configurations |
+| `instances` | Yes | array | List of contract instances to index |
+| `enableCallHandlers` | No | boolean | Enable call handler indexing for all instances |
+
+### ABI Configuration (`abis`)
+
+Each key in `abis` is a name you choose. The value is an ABI source:
+
+**File path:**
+```json
+"abis": {
+  "ERC20": {
+    "path": "./erc20-abi.json"
+  }
+}
+```
+
+**Inline ABI (raw array):**
+```json
+"abis": {
+  "ERC20": [
+    {
+      "type": "event",
+      "name": "Transfer",
+      "inputs": [
+        {"indexed": true, "name": "from", "type": "address"},
+        {"indexed": true, "name": "to", "type": "address"},
+        {"indexed": false, "name": "value", "type": "uint256"}
+      ]
+    }
+  ]
+}
+```
+
+### Instance Configuration (`instances`)
+
+Each instance represents a contract deployment to index:
+
+| Field | Required | Type | Description |
+| ----- | -------- | ---- | ----------- |
+| `abi` | Yes | string | Must match a key in `abis` |
+| `address` | Yes | string | Contract address (0x-prefixed) |
+| `chain` | Yes | string | Chain slug (e.g., `mainnet`, `base`, `matic`) |
+| `startBlock` | No | number | Block to start indexing from |
+
+**Multiple contracts:**
+```json
+"instances": [
+  {
+    "abi": "ERC20",
+    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "chain": "mainnet",
+    "startBlock": 6082465
+  },
+  {
+    "abi": "ERC721",
+    "address": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+    "chain": "mainnet",
+    "startBlock": 12287507
+  }
+]
+```
+
+**Same contract, multiple chains:**
+```json
+"instances": [
+  {
+    "abi": "USDC",
+    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "chain": "mainnet",
+    "startBlock": 6082465
+  },
+  {
+    "abi": "USDC",
+    "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "chain": "base",
+    "startBlock": 1000000
+  }
+]
+```
+
+> **Note:** Multiple chains in the configuration result in multiple subgraphs being deployed.
+
+### Enrichments (eth_call)
+
+See `references/enrichments.md` for full enrichment configuration.
+
+---
+
+## Source Code Subgraph Structure
+
+When deploying with `--path .`, your directory should contain:
+
+```
+my-subgraph/
+  subgraph.yaml      # Manifest — data sources, entities, event handlers
+  schema.graphql      # Entity definitions (GraphQL schema)
+  src/
+    mapping.ts        # AssemblyScript event handlers
+  abis/
+    MyContract.json   # Contract ABI(s)
+```
+
+### subgraph.yaml Structure
+
+```yaml
+specVersion: 0.0.4
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: MyContract
+    network: mainnet
+    source:
+      address: "0x1234...abcd"
+      abi: MyContract
+      startBlock: 12345678
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Transfer
+      abis:
+        - name: MyContract
+          file: ./abis/MyContract.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+      callHandlers:    # Optional
+        - function: approve(address,uint256)
+          handler: handleApprove
+      file: ./src/mapping.ts
+```
+
+---
+
+## GraphQL Endpoint Formats
+
+After deployment, you receive GraphQL endpoints:
+
+| Type | Format |
+| ---- | ------ |
+| Versioned (private) | `https://api.goldsky.com/api/private/<project-hash>/subgraphs/<name>/<version>/gn` |
+| Tagged (private) | `https://api.goldsky.com/api/private/<project-hash>/subgraphs/<name>/<tag>/gn` |
+| Public | `https://api.goldsky.com/api/public/<project-hash>/subgraphs/<name>/<version>/gn` |
+
+**Private endpoints** require a Bearer token in the Authorization header:
+```
+Authorization: Bearer <your-api-key>
+```
+
+To toggle public/private endpoints:
+```bash
+goldsky subgraph update name/version --public-endpoint true
+goldsky subgraph update name/version --private-endpoint true
+```
+
+---
+
+## Common Chain Slugs (Subgraphs)
+
+> **Full list:** See `data/subgraph-chain-slugs.json` or [Goldsky Supported Networks](https://docs.goldsky.com/chains/supported-networks).
+
+| Chain | Slug | Notes |
+| ----- | ---- | ----- |
+| Ethereum | `mainnet` | **Not** `ethereum` — different from Turbo datasets |
+| Base | `base` | |
+| Polygon | `matic` | **Not** `polygon` |
+| Arbitrum One | `arbitrum-one` | |
+| Optimism | `optimism` | |
+| BNB Chain | `bsc` | |
+| Avalanche | `avalanche` | |
+| Gnosis | `xdai` | **Not** `gnosis` |
+| Fantom | `fantom` | |
+| zkSync Era | `zksync-era` | |
+| Linea | `linea` | |
+| Scroll | `scroll` | |
+| Blast | `blast` | |
+| Zora | `zora` | |
+| Mode | `mode-mainnet` | |
+
+> **Important:** Subgraph chain slugs differ from Turbo dataset prefixes in some cases (e.g., `mainnet` vs `ethereum`, `arbitrum-one` vs `arbitrum`). Always use the subgraph-specific slug.
+
+---
+
+## Common Configuration Patterns
+
+### Minimal Instant Subgraph (Single Contract)
+
+```json
+{
+  "version": "1",
+  "abis": {
+    "USDC": {
+      "path": "./usdc-abi.json"
+    }
+  },
+  "instances": [
+    {
+      "abi": "USDC",
+      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "chain": "mainnet",
+      "startBlock": 6082465
+    }
+  ]
+}
+```
+
+### Multiple Contracts with Different ABIs
+
+```json
+{
+  "version": "1",
+  "abis": {
+    "ERC20": { "path": "./erc20-abi.json" },
+    "UniswapV2Pair": { "path": "./uniswap-pair-abi.json" }
+  },
+  "instances": [
+    {
+      "abi": "ERC20",
+      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "chain": "mainnet",
+      "startBlock": 6082465
+    },
+    {
+      "abi": "UniswapV2Pair",
+      "address": "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc",
+      "chain": "mainnet",
+      "startBlock": 10008355
+    }
+  ]
+}
+```
+
+---
+
+## Related
+
+- **`/subgraph-architecture`** — High-level design decisions (subgraph vs pipeline, cross-chain strategies)
+- **`/subgraph-builder`** — Interactive wizard to deploy subgraphs step-by-step
+- **`/subgraph-doctor`** — Diagnose and fix subgraph issues
+- **`/subgraph-lifecycle`** — Pause, start, delete, tags, webhooks
+- **`/subgraph-migrate`** — Migrate from TheGraph or Alchemy

--- a/skills/subgraph-config/data/subgraph-chain-slugs.json
+++ b/skills/subgraph-config/data/subgraph-chain-slugs.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Chain slugs supported for Goldsky subgraphs. Note: subgraph slugs may differ from Turbo dataset prefixes.",
+  "lastUpdated": "2026-03-18",
+  "commonChains": [
+    {
+      "name": "Ethereum",
+      "slug": "mainnet",
+      "note": "Not 'ethereum' — differs from Turbo dataset prefix"
+    },
+    {
+      "name": "Base",
+      "slug": "base"
+    },
+    {
+      "name": "Polygon",
+      "slug": "matic",
+      "note": "Not 'polygon'"
+    },
+    {
+      "name": "Arbitrum One",
+      "slug": "arbitrum-one",
+      "note": "Not 'arbitrum' — differs from Turbo"
+    },
+    {
+      "name": "Arbitrum Nova",
+      "slug": "arbitrum-nova"
+    },
+    {
+      "name": "Optimism",
+      "slug": "optimism"
+    },
+    {
+      "name": "BNB Chain",
+      "slug": "bsc"
+    },
+    {
+      "name": "Avalanche",
+      "slug": "avalanche"
+    },
+    {
+      "name": "Gnosis",
+      "slug": "xdai",
+      "note": "Not 'gnosis'"
+    },
+    {
+      "name": "Fantom",
+      "slug": "fantom"
+    },
+    {
+      "name": "zkSync Era",
+      "slug": "zksync-era"
+    },
+    {
+      "name": "Linea",
+      "slug": "linea"
+    },
+    {
+      "name": "Scroll",
+      "slug": "scroll"
+    },
+    {
+      "name": "Blast",
+      "slug": "blast"
+    },
+    {
+      "name": "Zora",
+      "slug": "zora"
+    },
+    {
+      "name": "Mode",
+      "slug": "mode-mainnet"
+    },
+    {
+      "name": "Mantle",
+      "slug": "mantle"
+    },
+    {
+      "name": "Celo",
+      "slug": "celo"
+    },
+    {
+      "name": "Moonbeam",
+      "slug": "moonbeam"
+    },
+    {
+      "name": "Sonic",
+      "slug": "sonic"
+    },
+    {
+      "name": "Monad",
+      "slug": "monad"
+    },
+    {
+      "name": "Berachain",
+      "slug": "berachain-mainnet"
+    },
+    {
+      "name": "Unichain",
+      "slug": "unichain"
+    },
+    {
+      "name": "Abstract",
+      "slug": "abstract"
+    },
+    {
+      "name": "Story",
+      "slug": "story"
+    },
+    {
+      "name": "Polygon zkEVM",
+      "slug": "polygon-zkevm"
+    },
+    {
+      "name": "Ink",
+      "slug": "ink"
+    },
+    {
+      "name": "World Chain",
+      "slug": "worldchain"
+    },
+    {
+      "name": "Ronin",
+      "slug": "ronin"
+    },
+    {
+      "name": "Sei",
+      "slug": "sei"
+    },
+    {
+      "name": "Taiko",
+      "slug": "taiko"
+    },
+    {
+      "name": "Immutable zkEVM",
+      "slug": "imtbl-zkevm"
+    },
+    {
+      "name": "Build on Bitcoin (BOB)",
+      "slug": "bob"
+    },
+    {
+      "name": "HyperEVM",
+      "slug": "hyperevm"
+    },
+    {
+      "name": "MegaETH",
+      "slug": "megaeth-mainnet"
+    },
+    {
+      "name": "Filecoin",
+      "slug": "filecoin"
+    },
+    {
+      "name": "Kaia",
+      "slug": "kaia"
+    },
+    {
+      "name": "Moonriver",
+      "slug": "moonriver"
+    },
+    {
+      "name": "Metis",
+      "slug": "metis"
+    },
+    {
+      "name": "Swellchain",
+      "slug": "swell"
+    },
+    {
+      "name": "Apechain",
+      "slug": "apechain-mainnet"
+    }
+  ],
+  "testnets": [
+    {
+      "name": "Ethereum Sepolia",
+      "slug": "sepolia"
+    },
+    {
+      "name": "Ethereum Holesky",
+      "slug": "holesky"
+    },
+    {
+      "name": "Base Sepolia",
+      "slug": "base-sepolia"
+    },
+    {
+      "name": "Arbitrum Sepolia",
+      "slug": "arbitrum-sepolia"
+    },
+    {
+      "name": "Optimism Sepolia",
+      "slug": "optimism-sepolia"
+    },
+    {
+      "name": "Monad Testnet",
+      "slug": "monad-testnet"
+    },
+    {
+      "name": "Berachain Bepolia",
+      "slug": "berachain-bepolia"
+    }
+  ],
+  "commonMistakes": [
+    {
+      "wrong": "ethereum",
+      "correct": "mainnet",
+      "context": "Ethereum Mainnet"
+    },
+    {
+      "wrong": "polygon",
+      "correct": "matic",
+      "context": "Polygon Mainnet"
+    },
+    {
+      "wrong": "arbitrum",
+      "correct": "arbitrum-one",
+      "context": "Arbitrum One Mainnet"
+    },
+    {
+      "wrong": "gnosis",
+      "correct": "xdai",
+      "context": "Gnosis Chain"
+    },
+    {
+      "wrong": "binance",
+      "correct": "bsc",
+      "context": "BNB Smart Chain"
+    },
+    {
+      "wrong": "mode",
+      "correct": "mode-mainnet",
+      "context": "Mode Mainnet"
+    },
+    {
+      "wrong": "immutable",
+      "correct": "imtbl-zkevm",
+      "context": "Immutable zkEVM"
+    }
+  ],
+  "fullListUrl": "https://docs.goldsky.com/chains/supported-networks"
+}

--- a/skills/subgraph-config/evals/trigger-eval.json
+++ b/skills/subgraph-config/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "what fields go in the abis section of an instant subgraph config?", "should_trigger": true},
+  {"query": "what's the JSON schema for instant subgraph configuration version 1?", "should_trigger": true},
+  {"query": "how do I configure multiple chains in my instant subgraph instances array?", "should_trigger": true},
+  {"query": "what CLI flags does goldsky subgraph deploy accept?", "should_trigger": true},
+  {"query": "what is the chain slug for Polygon in subgraphs — is it matic or polygon?", "should_trigger": true},
+  {"query": "how do I set up enrichments with eth_call in my instant subgraph config?", "should_trigger": true},
+  {"query": "what's the difference between subgraph.yaml and the instant subgraph JSON format?", "should_trigger": true},
+  {"query": "what's the --from-abi flag for and how do I use it?", "should_trigger": true},
+  {"query": "what chains support Goldsky subgraphs? Is Blast supported?", "should_trigger": true},
+  {"query": "help me deploy a new subgraph from scratch step by step", "should_trigger": false},
+  {"query": "my subgraph is in error state and I need help diagnosing the issue", "should_trigger": false},
+  {"query": "how do I migrate my subgraph from TheGraph using an IPFS hash?", "should_trigger": false},
+  {"query": "how do I pause my subgraph and then resume it later?", "should_trigger": false},
+  {"query": "what's the YAML field for setting a primary key on a postgres sink in Turbo?", "should_trigger": false},
+  {"query": "how do I create a webhook for my subgraph entities?", "should_trigger": false}
+]

--- a/skills/subgraph-config/references/enrichments.md
+++ b/skills/subgraph-config/references/enrichments.md
@@ -1,0 +1,104 @@
+# Enrichments Reference
+
+Enrichments allow instant subgraphs to make `eth_call` requests within event handlers, enabling you to read on-chain state at the time an event is processed.
+
+## When to Use Enrichments
+
+- Reading token balances, allowances, or metadata at the time of a transfer
+- Fetching contract state (e.g., pool reserves, token prices) when an event fires
+- Enriching event data with additional on-chain context
+
+## Configuration
+
+Enrichments are configured per-instance in the instant subgraph JSON config:
+
+```json
+{
+  "version": "1",
+  "abis": {
+    "ERC20": { "path": "./erc20-abi.json" }
+  },
+  "instances": [
+    {
+      "abi": "ERC20",
+      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "chain": "mainnet",
+      "startBlock": 6082465,
+      "enrichments": [
+        {
+          "name": "totalSupply",
+          "source": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "name": "balanceOf",
+          "params": "event.params.to",
+          "source": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Enrichment Call Fields
+
+| Field | Required | Type | Description |
+| ----- | -------- | ---- | ----------- |
+| `name` | Yes | string | The exact name of the eth call as defined in the ABI. The runtime calls `try_<name>` to safely handle reverts. |
+| `abi` | No | string | Name of the ABI defining the call (defaults to the instance ABI) |
+| `source` | No | string | Contract address expression for the call (defaults to the instance address) |
+| `params` | No | string | Parameter expression for the eth call. Omit if the call takes no parameters. Multiple params separated by commas, e.g., `"event.params.owner, event.params.tokenId"` |
+| `depends_on` | No | array of string | List of call reference names this call depends on. Use when a parameter is derived from a previously defined call. |
+| `required` | No | boolean | If true, the call must succeed or the enrichment is aborted and the subgraph enters error state |
+| `declared` | No | boolean | If true, the call is executed and cached before the mapping handler runs (performance optimization — can reduce indexing time up to 10x) |
+| `conditions` | No | object | Optional pre/post condition expressions to test before/after the call |
+| `conditions.pre` | No | string | Condition to test before performing the call |
+| `conditions.post` | No | string | Condition to test after performing the call |
+
+## Enrichment Expressions
+
+Expressions are AssemblyScript expressions that produce values from the runtime context:
+
+- **`event`** / **`call`** — The incoming event/call object with parameters converted to entity fields
+- **`entity`** — The parent entity object (already saved before enrichment begins)
+- **`calls`** — Object containing results of previously executed eth calls
+
+Expressions support string concatenation, type transformations, math, and logical branching.
+
+## Advanced Example: Chained Calls with Dependencies
+
+```json
+"enrichments": [
+  {
+    "name": "token0",
+    "required": true
+  },
+  {
+    "name": "token1",
+    "required": true
+  },
+  {
+    "name": "symbol",
+    "abi": "ERC20",
+    "source": "calls.token0",
+    "depends_on": ["token0"]
+  },
+  {
+    "name": "decimals",
+    "abi": "ERC20",
+    "source": "calls.token0",
+    "depends_on": ["token0"],
+    "declared": true
+  }
+]
+```
+
+## Notes
+
+- Enrichments increase indexing time as they require RPC calls for each event
+- The called function must be a `view` or `pure` function (read-only)
+- Use `declared: true` for frequently called functions to pre-execute and cache results (up to 10x faster indexing)
+- Always use `try_` prefix when calling contract methods in handlers to safely handle reverts
+- Results are available in the generated mapping code via the `calls` object
+- For complex enrichment logic, consider using source code subgraphs with custom handlers instead
+- If `required: true` and the call fails, the enrichment is aborted — no entity mapping takes place

--- a/skills/subgraph-doctor/SKILL.md
+++ b/skills/subgraph-doctor/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: subgraph-doctor
+description: "Diagnose and fix broken Goldsky subgraphs interactively. Use whenever the user has a specific subgraph that is misbehaving — stalled indexing, error state, not syncing, 524 timeout errors, store errors, mapping failures, subgraph paused unexpectedly, slow sync progress, GraphQL endpoint returning stale data, or any symptom where a deployed subgraph is not working correctly. Runs goldsky subgraph log and list commands, identifies root cause, and offers fixes. For looking up CLI syntax or error message definitions WITHOUT an active problem, use /subgraph-monitor-debug instead. For deploying new subgraphs, use /subgraph-builder."
+---
+
+# Subgraph Doctor
+
+## Boundaries
+
+- Diagnose and fix EXISTING subgraph problems interactively.
+- Do not build new subgraphs — that belongs to `/subgraph-builder`.
+- Do not serve as a command reference. If the user only needs CLI syntax or error pattern lookup, use `/subgraph-monitor-debug` or `/subgraph-lifecycle`.
+
+Systematically identify and resolve subgraph issues by following a structured diagnostic workflow.
+
+## Mode Detection
+
+Before running any commands, check if you have the `Bash` tool available:
+
+- **If Bash is available** (CLI mode): Execute commands directly and parse output.
+- **If Bash is NOT available** (reference mode): Output commands for the user to run. Ask them to paste the output back so you can analyze it.
+
+## Diagnostic Workflow
+
+Follow these steps in order. Do not skip steps — each builds on the previous one.
+
+### Step 1: Verify Authentication
+
+Run `goldsky project list 2>&1` to check login status.
+
+- **If logged in:** Note the current project and continue.
+- **If not logged in:** Tell the user they need to authenticate. Use the `/auth-setup` skill for guidance. Do not proceed until auth is confirmed.
+
+### Step 2: Identify the Subgraph
+
+Run `goldsky subgraph list` to show all subgraphs.
+
+Ask the user which subgraph they want to diagnose. If they already named one, confirm it exists in the list.
+
+Note the subgraph's current status (Indexing, Synced, Paused, Error).
+
+### Step 3: Analyze Subgraph Status
+
+Based on the status:
+
+- **Indexing** — Subgraph is active but may be slow or producing wrong data. Check sync progress and logs. Proceed to Step 4.
+- **Synced** — Subgraph is caught up. If user reports issues, check data quality or endpoint access. Proceed to Step 4.
+- **Error** — Subgraph has failed. Most common case. Proceed to Step 4 for log analysis.
+- **Paused** — Subgraph was manually paused or auto-paused due to stalling. Ask if they want to investigate the cause before resuming.
+
+### Step 4: Examine Logs
+
+Run `goldsky subgraph log <name>/<version> 2>&1` to get recent logs.
+
+Analyze the output for known error patterns. Reference the error patterns in `/subgraph-monitor-debug`, including:
+
+- **Mapping errors** — handler crashes, null access, type mismatches
+- **Store errors** — entity conflicts, duplicate IDs, schema mismatches
+- **Deployment errors** — IPFS timeouts, build failures, graft issues
+- **RPC errors** — upstream node issues (usually transient)
+- **Stall indicators** — no progress on block processing
+
+### Step 5: Check Configuration (if applicable)
+
+If logs show configuration-related errors:
+
+- Verify the subgraph exists: `goldsky subgraph list <name>`
+- Check if it's the right project: `goldsky project list`
+- For instant subgraphs, check for ABI/column conflicts
+- For source code subgraphs, check event signatures match the deployed contract
+
+### Step 6: Provide Diagnosis
+
+Present your findings in this format:
+
+```
+## Diagnosis
+
+**Subgraph:** [name/version]
+**Status:** [status]
+**Issue:** [one-line summary]
+
+**Root cause:**
+[Detailed explanation of what's wrong]
+
+**Evidence:**
+- [Log line or observation 1]
+- [Log line or observation 2]
+
+**Recommended fix:**
+1. [Step 1]
+2. [Step 2]
+
+**Prevention:**
+[How to avoid this in the future]
+```
+
+### Step 7: Offer to Fix
+
+If the fix involves CLI commands, offer to execute them. Always confirm with the user before making changes.
+
+Common fixes:
+
+- **Resume a paused subgraph:**
+  ```bash
+  goldsky subgraph start <name>/<version>
+  ```
+
+- **Redeploy with fixes:**
+  ```bash
+  goldsky subgraph deploy <name>/<new-version> --path .
+  ```
+
+- **Redeploy instant subgraph:**
+  ```bash
+  goldsky subgraph deploy <name>/<new-version> --from-abi config.json
+  ```
+
+- **Delete and start fresh:**
+  ```bash
+  goldsky subgraph delete <name>/<version>
+  goldsky subgraph deploy <name>/<version> --path .
+  ```
+
+- **Remove graft issues:**
+  ```bash
+  goldsky subgraph deploy <name>/<new-version> --from-ipfs-hash <hash> --remove-graft
+  ```
+
+## Important Rules
+
+- Never guess at the problem. Always check logs and status first.
+- If you're unsure, say so and suggest what additional information would help.
+- Always ask before running destructive commands (delete).
+- If the issue is a handler/mapping bug, the user needs to fix their code and redeploy a new version.
+- For stalled subgraphs that were auto-paused, fix the underlying issue before resuming.
+- If the issue is beyond what the CLI can diagnose, suggest contacting Goldsky support at support@goldsky.com with the specific error messages.
+
+## Related
+
+- **`/subgraph-monitor-debug`** — CLI command reference and error pattern lookup
+- **`/subgraph-lifecycle`** — Pause, start, delete, tag commands
+- **`/subgraph-builder`** — Build and deploy new subgraphs
+- **`/subgraph-config`** — Configuration reference
+- **`/auth-setup`** — CLI authentication

--- a/skills/subgraph-doctor/evals/trigger-eval.json
+++ b/skills/subgraph-doctor/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "my subgraph stopped syncing and I can't figure out why", "should_trigger": true},
+  {"query": "my subgraph is in error state, can you help me diagnose what went wrong?", "should_trigger": true},
+  {"query": "the GraphQL endpoint for my subgraph is returning stale data from hours ago", "should_trigger": true},
+  {"query": "my subgraph got auto-paused and I received a stall notification, what do I do?", "should_trigger": true},
+  {"query": "I'm getting store errors in my subgraph logs, help me fix it", "should_trigger": true},
+  {"query": "my subgraph deployed but it's been stuck at block 1234567 for 30 minutes", "should_trigger": true},
+  {"query": "my nouns-subgraph keeps crashing with a mapping handler error", "should_trigger": true},
+  {"query": "subgraph is showing 524 timeout errors when I query the GraphQL endpoint", "should_trigger": true},
+  {"query": "my subgraph was working fine yesterday but now it's paused and not indexing", "should_trigger": true},
+  {"query": "I want to create a new subgraph to index my smart contract", "should_trigger": false},
+  {"query": "what does the goldsky subgraph log command do and what flags does it accept?", "should_trigger": false},
+  {"query": "how do I migrate my existing TheGraph subgraph to Goldsky?", "should_trigger": false},
+  {"query": "how do I set up a tag for zero-downtime subgraph upgrades?", "should_trigger": false},
+  {"query": "my turbo pipeline is stuck in error state, help me debug it", "should_trigger": false},
+  {"query": "what's the chain slug for Ethereum subgraphs — mainnet or ethereum?", "should_trigger": false}
+]

--- a/skills/subgraph-lifecycle/SKILL.md
+++ b/skills/subgraph-lifecycle/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: subgraph-lifecycle
+description: "Subgraph state management, tags, and webhooks — pause, start, delete, tag, update, and webhook commands with their rules and behaviors. Use this skill when the user asks: how do I pause a subgraph, how do I resume/start a paused subgraph, how do I delete a subgraph version, how do I create or manage tags for zero-downtime version swaps, how do I toggle public/private GraphQL endpoints, how do I create a webhook for subgraph entity changes, how do I list or delete webhooks, what entities can I hook into, or how do I do a zero-downtime subgraph upgrade. For actively diagnosing why a subgraph is broken, use /subgraph-doctor instead. For deploying new subgraphs, use /subgraph-builder."
+---
+
+# Subgraph Lifecycle Reference
+
+CLI commands for managing subgraph state, tags, endpoints, and webhooks. For interactive subgraph troubleshooting, use `/subgraph-doctor` instead.
+
+---
+
+## Quick Reference
+
+| Action | Command |
+| ------ | ------- |
+| List all subgraphs | `goldsky subgraph list` |
+| List specific subgraph | `goldsky subgraph list name/version` |
+| Pause subgraph | `goldsky subgraph pause name/version` |
+| Start/resume subgraph | `goldsky subgraph start name/version` |
+| Delete subgraph | `goldsky subgraph delete name/version` |
+| View logs | `goldsky subgraph log name/version` |
+| Update endpoint settings | `goldsky subgraph update name/version` |
+
+---
+
+## Subgraph States
+
+| State | Description |
+| ----- | ----------- |
+| Indexing | Subgraph is actively syncing and processing blocks |
+| Synced | Subgraph is caught up to the chain tip and indexing new blocks in real time |
+| Paused | Subgraph was manually paused or auto-paused due to stalling |
+| Error | Subgraph encountered a fatal error during indexing |
+
+---
+
+## Lifecycle Commands
+
+### Pause
+
+```bash
+goldsky subgraph pause name/version
+```
+
+Stops the subgraph from indexing. Useful for:
+- Reducing costs while not actively querying
+- Pausing during maintenance
+- Investigating issues without the subgraph continuing to index bad data
+
+### Start / Resume
+
+```bash
+goldsky subgraph start name/version
+```
+
+Resumes a paused subgraph. It picks up from where it left off.
+
+### Delete
+
+```bash
+goldsky subgraph delete name/version
+```
+
+Permanently removes a subgraph version. **This is irreversible** — the subgraph data, GraphQL endpoint, and indexing progress are all deleted.
+
+**Before deleting:**
+- Move any tags pointing to this version to another version first
+- Ensure no frontend code depends on this specific version's endpoint
+
+### Update
+
+```bash
+goldsky subgraph update name/version --public-endpoint true
+goldsky subgraph update name/version --private-endpoint true
+```
+
+Toggle public/private endpoint visibility. By default, subgraphs have private endpoints that require an API key.
+
+---
+
+## Tag Management
+
+Tags are aliases that point to a specific subgraph version. They enable zero-downtime upgrades by keeping a stable GraphQL endpoint URL while swapping the underlying version.
+
+### Create a Tag
+
+```bash
+goldsky subgraph tag create name/version --tag prod
+```
+
+This creates (or moves) the `prod` tag to point to `name/version`. The tagged GraphQL endpoint uses the tag name instead of the version number.
+
+### Delete a Tag
+
+```bash
+goldsky subgraph tag delete name/version --tag prod
+```
+
+Removes the tag association from this version.
+
+### Zero-Downtime Upgrade Pattern
+
+1. Deploy new version:
+   ```bash
+   goldsky subgraph deploy my-subgraph/2.0.0 --path .
+   ```
+
+2. Wait for it to sync (check with `goldsky subgraph list`).
+
+3. Move the tag to the new version:
+   ```bash
+   goldsky subgraph tag create my-subgraph/2.0.0 --tag prod
+   ```
+
+4. Verify the tagged endpoint is serving data from v2:
+   - Query `{ _meta { deployment } }` to confirm
+
+5. Delete the old version (optional):
+   ```bash
+   goldsky subgraph delete my-subgraph/1.0.0
+   ```
+
+**Key points:**
+- Frontend code uses the tagged endpoint URL, which never changes
+- Moving a tag is instant — no downtime, no stale data
+- You can have multiple tags (e.g., `prod`, `staging`, `dev`)
+
+### GraphQL Endpoint Formats
+
+| Type | Format |
+| ---- | ------ |
+| Versioned | `.../subgraphs/name/1.0.0/gn` |
+| Tagged | `.../subgraphs/name/prod/gn` |
+
+---
+
+## Webhooks
+
+Subgraph webhooks send HTTP POST requests to your endpoint whenever a subgraph entity changes. Use for notifications, backend updates, or real-time reactions to indexed events.
+
+> **For guaranteed data delivery to a database**, use Mirror pipelines with a subgraph source instead of webhooks. Webhooks are best for notifications and lightweight integrations.
+
+### Webhook Commands
+
+| Action | Command |
+| ------ | ------- |
+| Create webhook | `goldsky subgraph webhook create name/version` |
+| List all webhooks | `goldsky subgraph webhook list` |
+| Delete webhook | `goldsky subgraph webhook delete <webhook-name>` |
+| List available entities | `goldsky subgraph webhook list-entities name/version` |
+
+### Create a Webhook
+
+```bash
+goldsky subgraph webhook create name/version \
+  --name my-webhook \
+  --url https://my-server.com/webhook \
+  --entity Transfer
+```
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `--name` | Yes | Unique name for this webhook |
+| `--url` | Yes | HTTP endpoint to receive POST requests |
+| `--entity` | Yes | Entity name to watch (from `list-entities`) |
+| `--secret` | No | Secret for request verification (auto-generated if omitted) |
+
+### List Webhook Entities
+
+Before creating a webhook, check which entities are available:
+
+```bash
+goldsky subgraph webhook list-entities name/version
+```
+
+This returns all entity types defined in the subgraph's schema.
+
+### Delete a Webhook
+
+```bash
+goldsky subgraph webhook delete my-webhook
+# Or force without confirmation:
+goldsky subgraph webhook delete my-webhook --force
+```
+
+### Webhook Payload
+
+Webhooks send a JSON POST request to your URL for every entity change. The payload includes the entity data and metadata. Your endpoint should return a `200` status code to acknowledge receipt.
+
+---
+
+## Common Patterns
+
+### Version Promotion
+
+```bash
+# Deploy to staging
+goldsky subgraph deploy my-subgraph/2.0.0 --path . --tag staging
+
+# Test via staging endpoint
+# ...
+
+# Promote to production
+goldsky subgraph tag create my-subgraph/2.0.0 --tag prod
+```
+
+### Rollback
+
+```bash
+# Move tag back to previous version
+goldsky subgraph tag create my-subgraph/1.0.0 --tag prod
+```
+
+### Cleanup Old Versions
+
+```bash
+# List all versions
+goldsky subgraph list my-subgraph
+
+# Delete old versions (ensure no tags point to them)
+goldsky subgraph delete my-subgraph/1.0.0
+```
+
+---
+
+## Related
+
+- **`/subgraph-builder`** — Deploy new subgraphs step-by-step
+- **`/subgraph-doctor`** — Diagnose and fix subgraph issues
+- **`/subgraph-config`** — Configuration reference and CLI flags
+- **`/subgraph-monitor-debug`** — Error patterns and log analysis

--- a/skills/subgraph-lifecycle/evals/trigger-eval.json
+++ b/skills/subgraph-lifecycle/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "how do I pause my subgraph while I investigate an issue?", "should_trigger": true},
+  {"query": "how do I create a tag for my subgraph so I can do zero-downtime upgrades?", "should_trigger": true},
+  {"query": "how do I delete an old subgraph version I no longer need?", "should_trigger": true},
+  {"query": "how do I resume a paused subgraph?", "should_trigger": true},
+  {"query": "I want to set up a webhook that fires whenever a new Transfer entity is indexed", "should_trigger": true},
+  {"query": "how do tags work for subgraph versioning and what's the CLI command?", "should_trigger": true},
+  {"query": "how do I toggle my subgraph endpoint between public and private?", "should_trigger": true},
+  {"query": "how do I list the available webhook entities for my subgraph?", "should_trigger": true},
+  {"query": "I want to promote my subgraph from staging to production using tags", "should_trigger": true},
+  {"query": "help me deploy a new subgraph from scratch for my NFT contract", "should_trigger": false},
+  {"query": "my subgraph is stuck and returning stale data, help me diagnose it", "should_trigger": false},
+  {"query": "what's the JSON config format for an instant subgraph?", "should_trigger": false},
+  {"query": "how do I migrate my TheGraph subgraph to Goldsky?", "should_trigger": false},
+  {"query": "how do I pause a turbo pipeline?", "should_trigger": false},
+  {"query": "what does the 'mapping handler error' mean in my subgraph logs?", "should_trigger": false}
+]

--- a/skills/subgraph-migrate/SKILL.md
+++ b/skills/subgraph-migrate/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: subgraph-migrate
+description: "Migrate an existing subgraph to Goldsky from TheGraph, Alchemy, or any other subgraph hosting provider. Use when the user says 'migrate my subgraph', 'move from TheGraph to Goldsky', 'I have an IPFS hash for my subgraph', 'deploy from TheGraph explorer', 'migrate from Alchemy', 'migrate from Satsuma', or 'I want to run my existing subgraph on Goldsky'. Covers one-step IPFS migration from TheGraph, Alchemy-to-Goldsky workflow differences, tag migration, graft handling, and post-migration verification. Do NOT use for creating new subgraphs from scratch (use /subgraph-builder), diagnosing broken subgraphs (use /subgraph-doctor), or managing existing Goldsky subgraphs (use /subgraph-lifecycle)."
+---
+
+# Subgraph Migration
+
+## Boundaries
+
+- Migrate EXISTING subgraphs from other hosts to Goldsky.
+- Do not build new subgraphs from scratch — that belongs to `/subgraph-builder`.
+- Do not diagnose broken subgraphs — use `/subgraph-doctor`.
+- For post-migration tag and lifecycle management, use `/subgraph-lifecycle`.
+
+Guide the user through migrating their subgraph to Goldsky with zero downtime.
+
+## Mode Detection
+
+Before running any commands, check if you have the `Bash` tool available:
+
+- **If Bash is available** (CLI mode): Execute commands directly.
+- **If Bash is NOT available** (reference mode): Provide copy-paste commands.
+
+## Migration Workflow
+
+### Step 1: Verify Authentication
+
+Run `goldsky project list 2>&1` to check login status.
+
+- **If logged in:** Note the current project and continue.
+- **If not logged in:** Use the `/auth-setup` skill for guidance.
+
+### Step 2: Determine Source Platform
+
+Ask the user where their subgraph is currently hosted:
+
+| Source | Migration Path |
+| ------ | -------------- |
+| TheGraph (decentralized network) | IPFS hash migration |
+| TheGraph (hosted service) | IPFS hash or URL migration |
+| Alchemy / Satsuma | Source code deployment (`--path .`) |
+| Other GraphQL endpoint | URL migration (`--from-url`) |
+| Local source code | Source code deployment (`--path .`) |
+
+### Step 3: Execute Migration
+
+#### Path A: TheGraph via IPFS Hash (Most Common)
+
+**Get the IPFS hash** — two ways:
+
+1. From TheGraph Explorer UI — find the deployment hash on the subgraph's page
+2. From any GraphQL endpoint — query:
+   ```graphql
+   {
+     _meta {
+       deployment
+     }
+   }
+   ```
+
+**Deploy to Goldsky:**
+
+```bash
+goldsky subgraph deploy <name>/<version> --from-ipfs-hash <ipfs-hash>
+```
+
+Example:
+```bash
+goldsky subgraph deploy uniswap-v3/1.0.0 --from-ipfs-hash QmXyz123abc456
+```
+
+**Optional flags:**
+- `--tag prod` — immediately tag for a stable endpoint
+- `--start-block <N>` — override the start block
+- `--remove-graft` — remove graft dependencies (recommended for clean migration)
+
+#### Path B: URL Migration
+
+For subgraphs accessible via a public GraphQL endpoint:
+
+```bash
+goldsky subgraph deploy <name>/<version> --from-url <graphql-endpoint>
+```
+
+#### Path C: Alchemy / Source Code Migration
+
+Alchemy subgraphs can be migrated two ways:
+
+**Option 1: Via IPFS hash (try this first):**
+```bash
+goldsky subgraph deploy <name>/<version> --from-ipfs-hash <hash> --ipfs-gateway https://ipfs.satsuma.xyz
+```
+
+> **Note:** Use the Satsuma IPFS gateway (`https://ipfs.satsuma.xyz`) for Alchemy subgraphs. The default TheGraph gateway won't resolve Alchemy hashes. This method does not always work — if it fails, use Option 2.
+
+**Option 2: From source code:**
+1. Ensure you have the subgraph source code locally (subgraph.yaml, schema.graphql, mappings)
+2. Deploy:
+   ```bash
+   goldsky subgraph deploy <name>/<version> --path .
+   ```
+
+Alchemy and Goldsky implement tags differently. See `/subgraph-lifecycle` for Goldsky tag management.
+
+### Step 4: Handle Grafts
+
+If the source subgraph uses grafting:
+
+- **Option A:** Remove the graft and index from scratch:
+  ```bash
+  goldsky subgraph deploy <name>/<version> --from-ipfs-hash <hash> --remove-graft
+  ```
+
+- **Option B:** Graft from an existing Goldsky subgraph:
+  ```bash
+  goldsky subgraph deploy <name>/<version> --from-ipfs-hash <hash> \
+    --graft-from existing-subgraph/1.0.0 \
+    --start-block <graft-block>
+  ```
+
+> **Recommendation:** Use `--remove-graft` for clean migrations. The subgraph will re-index from its defined start block.
+
+### Step 5: Verify Deployment
+
+```bash
+goldsky subgraph list
+```
+
+Check:
+- Subgraph appears in the list
+- Status shows "Indexing" or "Synced"
+- GraphQL endpoint is accessible
+
+Test a query against the new endpoint:
+```graphql
+{
+  _meta {
+    block {
+      number
+    }
+  }
+}
+```
+
+### Step 6: Set Up Tags for Zero-Downtime Swap
+
+Create a tag so your frontend can switch to Goldsky without changing URLs:
+
+```bash
+goldsky subgraph tag create <name>/<version> --tag prod
+```
+
+The tagged endpoint becomes your stable URL. See `/subgraph-lifecycle` for tag management.
+
+### Step 7: Present Migration Summary
+
+```
+## Migration Complete
+
+**Source:** [TheGraph / Alchemy / Other]
+**Name:** [name/version]
+**Status:** [Indexing / Synced]
+
+**Endpoints:**
+- Versioned: [versioned endpoint URL]
+- Tagged (prod): [tagged endpoint URL]
+
+**What Goldsky adds:**
+- 99.9%+ uptime with load-balanced RPC
+- Up to 6x faster indexing
+- Tags for zero-downtime version swaps
+- Built-in webhooks for notifications
+- Auto-recovery from data consistency issues
+- 24/7 monitoring with on-call support
+
+**Next steps:**
+- Update frontend to use the tagged endpoint
+- Set up webhooks if needed: `/subgraph-lifecycle`
+- Monitor sync progress: `goldsky subgraph list`
+- Delete old subgraph on previous host once fully migrated
+```
+
+## Important Rules
+
+- Always use `--remove-graft` unless the user specifically needs to graft from a Goldsky subgraph
+- IPFS hash migration is the simplest path from TheGraph — always try this first
+- If IPFS download times out (524 error), retry or try a different gateway with `--ipfs-gateway`
+- Subgraph names on Goldsky must start with a letter and contain only letters, numbers, underscores, and hyphens
+- Multiple chains require separate subgraph deployments
+- Migration from TheGraph is a drop-in replacement — same GraphQL API, same queries work
+
+## Related
+
+- **`/subgraph-builder`** — Build new subgraphs from scratch
+- **`/subgraph-lifecycle`** — Tag management and zero-downtime upgrades
+- **`/subgraph-config`** — CLI flags and configuration reference
+- **`/subgraph-doctor`** — Diagnose migration issues
+- **`/auth-setup`** — CLI installation and authentication

--- a/skills/subgraph-migrate/evals/trigger-eval.json
+++ b/skills/subgraph-migrate/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "I want to migrate my subgraph from TheGraph to Goldsky", "should_trigger": true},
+  {"query": "I have an IPFS hash for my subgraph, how do I deploy it on Goldsky?", "should_trigger": true},
+  {"query": "how do I move my existing subgraph from Alchemy to Goldsky?", "should_trigger": true},
+  {"query": "migrate my uniswap subgraph from TheGraph's decentralized network to Goldsky", "should_trigger": true},
+  {"query": "I want to deploy an existing subgraph from a GraphQL URL to Goldsky", "should_trigger": true},
+  {"query": "can I do a one-step migration from TheGraph to Goldsky?", "should_trigger": true},
+  {"query": "I'm switching from Satsuma to Goldsky, what's the migration process?", "should_trigger": true},
+  {"query": "how do I get the IPFS deployment hash from my TheGraph subgraph?", "should_trigger": true},
+  {"query": "I need to move my subgraph from TheGraph hosted service to Goldsky with zero downtime", "should_trigger": true},
+  {"query": "help me create a brand new subgraph for my smart contract from scratch", "should_trigger": false},
+  {"query": "my migrated subgraph is stuck and not syncing after deployment", "should_trigger": false},
+  {"query": "what chain slugs does Goldsky support for subgraphs?", "should_trigger": false},
+  {"query": "how do I set up tags after I've deployed my subgraph?", "should_trigger": false},
+  {"query": "how do I build a turbo pipeline to move blockchain data to postgres?", "should_trigger": false},
+  {"query": "what does the --remove-graft flag do?", "should_trigger": false}
+]

--- a/skills/subgraph-migrate/references/alchemy-migration.md
+++ b/skills/subgraph-migrate/references/alchemy-migration.md
@@ -1,0 +1,76 @@
+# Alchemy / Satsuma Migration Guide
+
+## Overview
+
+Migrating from Alchemy (formerly Satsuma) to Goldsky involves deploying your subgraph source code and migrating your tag workflow.
+
+## Key Differences
+
+| Feature | Alchemy | Goldsky |
+| ------- | ------- | ------- |
+| Deployment | `graph deploy` | `goldsky subgraph deploy name/version --path .` |
+| Versioning | Version labels | Explicit `name/version` format |
+| Tags | Managed via UI | CLI: `goldsky subgraph tag create name/version --tag prod` |
+| Webhooks | Not built-in | Built-in: `goldsky subgraph webhook create` |
+| Grafting | Standard subgraph grafting | Same + `--graft-from` flag for Goldsky-native grafting |
+
+## Migration Steps
+
+### 1. Prepare Source Code
+
+Ensure you have the complete subgraph source locally:
+- `subgraph.yaml` — manifest
+- `schema.graphql` — entity definitions
+- `src/` — AssemblyScript mappings
+- `abis/` — contract ABIs
+
+### 2. Deploy to Goldsky
+
+```bash
+goldsky subgraph deploy my-subgraph/1.0.0 --path .
+```
+
+### 3. Migrate Tags
+
+Goldsky tags work similarly to Alchemy's version labels:
+
+```bash
+# Create a prod tag pointing to your version
+goldsky subgraph tag create my-subgraph/1.0.0 --tag prod
+```
+
+The tagged endpoint becomes your stable URL for frontend integration.
+
+### 4. Update Frontend
+
+Replace your Alchemy GraphQL endpoint with the Goldsky tagged endpoint:
+- Old: `https://subgraph.satsuma-prod.com/<org>/my-subgraph/api`
+- New: `https://api.goldsky.com/api/public/<project-hash>/subgraphs/my-subgraph/prod/gn`
+
+### 5. Zero-Downtime Version Upgrades
+
+When deploying a new version:
+
+```bash
+# Deploy new version
+goldsky subgraph deploy my-subgraph/2.0.0 --path .
+
+# Wait for it to sync, then move the tag
+goldsky subgraph tag create my-subgraph/2.0.0 --tag prod
+
+# Clean up old version
+goldsky subgraph delete my-subgraph/1.0.0
+```
+
+## Pre-Migrated Subgraphs
+
+If Goldsky pre-migrated your subgraphs from Alchemy:
+- They may already be live and fully synced
+- Some may be in a **Paused** state if detected as inactive
+- Resume paused subgraphs: `goldsky subgraph start name/version`
+
+## Monitoring After Migration
+
+- Check status: `goldsky subgraph list`
+- View logs: `goldsky subgraph log name/version`
+- Dashboard: Navigate to app.goldsky.com for real-time indexing progress, query metrics, and error logs

--- a/skills/subgraph-monitor-debug/SKILL.md
+++ b/skills/subgraph-monitor-debug/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: subgraph-monitor-debug
+description: "Use this skill when the user needs to look up goldsky subgraph CLI syntax — flags and options for log, list, or status commands — or wants to understand what a specific subgraph error message means (store errors, IPFS timeouts, mapping failures, stalled subgraph notifications, 524 errors, column conflicts, graft errors). Also use for understanding stalled subgraph detection behavior and auto-pause policies. Distinguishing factor: this skill provides reference information and explanations. If the user has a broken subgraph and wants step-by-step interactive diagnosis, use /subgraph-doctor instead."
+---
+
+# Subgraph Monitoring & Debugging Reference
+
+CLI commands, error patterns, and troubleshooting reference for Goldsky subgraphs. For interactive subgraph diagnosis (running commands, checking logs, walking through fixes), use `/subgraph-doctor` instead.
+
+---
+
+## Quick Reference
+
+| Action | Command |
+| ------ | ------- |
+| List all subgraphs | `goldsky subgraph list` |
+| List specific subgraph | `goldsky subgraph list name/version` |
+| View logs | `goldsky subgraph log name/version` |
+| Pause subgraph | `goldsky subgraph pause name/version` |
+| Start/resume subgraph | `goldsky subgraph start name/version` |
+| Delete subgraph | `goldsky subgraph delete name/version` |
+
+---
+
+## Error Pattern Reference
+
+> **Detailed error patterns and solutions are in the `data/` folder.**
+
+| File | Contents |
+| ---- | -------- |
+| `error-patterns.json` | All known error patterns with causes and solutions |
+
+---
+
+## Common Error Patterns
+
+| Error Pattern | Likely Cause | Fix |
+| ------------- | ------------ | --- |
+| `column "x" specified more than once` | ABI name conflicts in instant subgraph config | Rename conflicting ABI entries or use distinct contract names |
+| `524 timeout` | IPFS metadata timeout during deployment | Retry deployment; if persistent, check IPFS hash or use `--ipfs-gateway` |
+| Mapping/handler crash | AssemblyScript runtime error in event handler | Check handler code for null access, overflow, or missing entity loads |
+| `store error` | Entity store write failure | Check for duplicate entity IDs or schema conflicts |
+| Graft error | Incompatible graft base or missing graft source | Use `--remove-graft` or verify the graft source exists |
+| Subgraph stalled | Indexing stopped making progress | Check logs for handler errors; may need code fix and redeploy |
+| RPC errors | Upstream node issues | Usually transient — Goldsky's load balancer retries automatically |
+| `subgraph not found` | Wrong name/version or wrong project | Verify with `goldsky subgraph list` and `goldsky project list` |
+
+---
+
+## Stalled Subgraph Detection
+
+Goldsky automatically monitors subgraphs for indexing issues:
+
+### How It Works
+
+1. **Warning stage:** If a subgraph stops making progress, Goldsky sends a stall warning notification
+2. **Auto-pause stage:** If the stall persists, the subgraph is automatically paused to prevent resource waste
+
+### When You Receive a Stall Notification
+
+1. **Check status:** `goldsky subgraph list name/version` or view in the Goldsky dashboard
+2. **Review logs:** `goldsky subgraph log name/version` — look for errors or warnings
+3. **Common fixes:**
+   - Update mapping code to handle edge cases
+   - Fix bugs in AssemblyScript handlers
+   - Adjust subgraph manifest configuration
+4. **Resume or redeploy:**
+   - If paused: `goldsky subgraph start name/version`
+   - If code changes needed: `goldsky subgraph deploy name/new-version --path .`
+5. **Monitor recovery:** Verify the subgraph is making progress again
+
+---
+
+## Mapping/Handler Issues
+
+| Issue | Fix |
+| ----- | --- |
+| Null entity access | Always check `entity != null` before accessing fields |
+| BigInt overflow | Use `BigInt` type, not `i32`/`i64` for large numbers |
+| Missing entity load | Call `Entity.load(id)` before accessing — entities may not exist yet |
+| Event parameter mismatch | Ensure event signature in subgraph.yaml matches the actual ABI exactly |
+| `store.set` with wrong type | Entity field types must match schema.graphql exactly |
+
+---
+
+## Deployment Issues
+
+| Issue | Fix |
+| ----- | --- |
+| `524 timeout` on deploy | IPFS download timeout — retry, or use a different `--ipfs-gateway` |
+| ABI column conflicts | Rename ABI entries in instant config to avoid duplicate event/field names |
+| Build fails | Check AssemblyScript compilation errors in the build output |
+| Wrong chain slug | Subgraphs use `mainnet` (not `ethereum`), `matic` (not `polygon`), `xdai` (not `gnosis`) |
+
+---
+
+## Common Issues Quick Reference
+
+| Symptom | Likely Cause | Quick Fix |
+| ------- | ------------ | --------- |
+| Subgraph not syncing | Handler error or stalled | Check logs for errors |
+| GraphQL returns stale data | Subgraph paused or stalled | Check status, resume if paused |
+| No data at all | Wrong start block or chain | Verify config in `/subgraph-config` |
+| 524 error on queries | Subgraph overloaded or down | Check status; contact support if persistent |
+| Wrong entities indexed | ABI mismatch | Verify ABI matches deployed contract |
+| Endpoint returns 401 | Missing/invalid API key | Use Bearer token for private endpoints |
+
+---
+
+## When to Contact Support
+
+Contact support@goldsky.com when:
+- Stalled subgraph with no errors in logs
+- Persistent 524 timeouts on queries (not deployment)
+- Data inconsistencies between chain and subgraph
+- Custom chain or dedicated indexer issues
+- Billing or resource limit questions
+
+---
+
+## Related
+
+- **`/subgraph-doctor`** — Interactive diagnostic skill for troubleshooting subgraphs
+- **`/subgraph-builder`** — Deploy new subgraphs
+- **`/subgraph-lifecycle`** — Pause, start, delete, tag commands
+- **`/subgraph-config`** — Configuration reference

--- a/skills/subgraph-monitor-debug/data/error-patterns.json
+++ b/skills/subgraph-monitor-debug/data/error-patterns.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Common error patterns in Goldsky subgraph logs and their solutions",
+  "lastUpdated": "2026-03-18",
+  "patterns": [
+    {
+      "id": "column_conflict",
+      "pattern": "column.*specified more than once",
+      "category": "configuration",
+      "severity": "error",
+      "description": "Duplicate column names in instant subgraph generated schema",
+      "causes": [
+        "Multiple ABIs with events that have the same field names",
+        "ABI name conflicts in instant subgraph config"
+      ],
+      "solutions": [
+        "Rename ABI entries in the instant config to use distinct names",
+        "Use separate subgraphs for conflicting contracts",
+        "Switch to source code subgraph with custom entity names"
+      ],
+      "relatedSkill": "/subgraph-config"
+    },
+    {
+      "id": "ipfs_timeout",
+      "pattern": "524|IPFS.*timeout|failed to fetch",
+      "category": "deployment",
+      "severity": "error",
+      "description": "Timeout when fetching subgraph from IPFS during migration",
+      "causes": [
+        "IPFS gateway is slow or unreachable",
+        "Invalid or expired IPFS hash",
+        "Large subgraph deployment package"
+      ],
+      "solutions": [
+        "Retry the deployment command",
+        "Try a different IPFS gateway: --ipfs-gateway https://ipfs.io",
+        "Verify the IPFS hash is correct on TheGraph Explorer",
+        "If persistent, contact Goldsky support"
+      ],
+      "relatedSkill": "/subgraph-migrate"
+    },
+    {
+      "id": "mapping_crash",
+      "pattern": "wasm trap|unreachable|handler.*error|mapping.*failed",
+      "category": "runtime",
+      "severity": "error",
+      "description": "AssemblyScript mapping handler crashed during execution",
+      "causes": [
+        "Null entity access without null check",
+        "Integer overflow (using i32 for large numbers)",
+        "Accessing non-existent entity fields",
+        "Division by zero",
+        "Event parameter type mismatch"
+      ],
+      "solutions": [
+        "Add null checks: if (entity != null) before accessing",
+        "Use BigInt type for large numbers",
+        "Verify event signatures match ABI exactly",
+        "Add try-catch or defensive checks in handlers",
+        "Check logs for the specific block/tx that caused the crash"
+      ]
+    },
+    {
+      "id": "store_error",
+      "pattern": "store error|entity.*conflict|store.*write.*failed",
+      "category": "runtime",
+      "severity": "error",
+      "description": "Failed to write entity to the subgraph store",
+      "causes": [
+        "Duplicate entity IDs being created",
+        "Schema mismatch between entity definition and store operation",
+        "Concurrent writes to the same entity"
+      ],
+      "solutions": [
+        "Ensure entity IDs are unique (use tx hash + log index pattern)",
+        "Verify entity field types match schema.graphql exactly",
+        "Load existing entity before modifying to avoid conflicts"
+      ]
+    },
+    {
+      "id": "graft_error",
+      "pattern": "graft.*error|graft.*failed|incompatible.*graft",
+      "category": "deployment",
+      "severity": "error",
+      "description": "Grafting from an existing subgraph failed",
+      "causes": [
+        "Graft source subgraph doesn't exist",
+        "Schema incompatibility between graft source and new subgraph",
+        "Graft source is from a different project"
+      ],
+      "solutions": [
+        "Verify graft source exists: goldsky subgraph list",
+        "Use --remove-graft flag to deploy without grafting",
+        "Ensure schemas are compatible between versions"
+      ],
+      "relatedSkill": "/subgraph-config"
+    },
+    {
+      "id": "subgraph_stalled",
+      "pattern": "stalled|no progress|indexing.*stopped",
+      "category": "runtime",
+      "severity": "warning",
+      "description": "Subgraph stopped making indexing progress",
+      "causes": [
+        "Handler error on a specific block causing repeated retries",
+        "RPC issues for the chain (usually transient)",
+        "Memory limit exceeded",
+        "Bug in mapping code that causes infinite loop or deadlock"
+      ],
+      "solutions": [
+        "Check logs for the block number where indexing stopped",
+        "Investigate the specific transaction/event at that block",
+        "Fix handler code and redeploy",
+        "If auto-paused, fix the issue then resume: goldsky subgraph start name/version"
+      ]
+    },
+    {
+      "id": "rpc_error",
+      "pattern": "rpc.*error|eth_call.*failed|provider.*error",
+      "category": "network",
+      "severity": "warning",
+      "description": "RPC call failed during indexing",
+      "causes": [
+        "Upstream RPC node issue (usually transient)",
+        "Rate limiting on RPC endpoint",
+        "Network congestion"
+      ],
+      "solutions": [
+        "Usually resolves automatically — Goldsky's load balancer retries",
+        "If persistent, contact Goldsky support",
+        "For custom chains, verify RPC endpoint is healthy"
+      ]
+    },
+    {
+      "id": "auth_error",
+      "pattern": "unauthorized|401|api key.*invalid",
+      "category": "authentication",
+      "severity": "error",
+      "description": "Authentication failed when querying the subgraph endpoint",
+      "causes": [
+        "Missing or invalid API key in Authorization header",
+        "Expired API key",
+        "Querying a private endpoint without authentication"
+      ],
+      "solutions": [
+        "Use Bearer token: Authorization: Bearer <api-key>",
+        "Generate a new API key from Project Settings",
+        "Enable public endpoint: goldsky subgraph update name/version --public-endpoint true"
+      ],
+      "relatedSkill": "/auth-setup"
+    },
+    {
+      "id": "build_failure",
+      "pattern": "build.*failed|compilation.*error|AssemblyScript.*error",
+      "category": "deployment",
+      "severity": "error",
+      "description": "Subgraph source code failed to compile",
+      "causes": [
+        "AssemblyScript syntax errors in mapping files",
+        "Type errors in entity handling code",
+        "Missing imports or dependencies",
+        "Incompatible graph-ts version"
+      ],
+      "solutions": [
+        "Fix compilation errors shown in the build output",
+        "Run graph codegen and graph build locally before deploying",
+        "Ensure graph-ts version is compatible",
+        "Check entity types match schema.graphql definitions"
+      ]
+    }
+  ],
+  "healthyIndicators": [
+    {
+      "pattern": "Processing block",
+      "meaning": "Subgraph is actively indexing blocks"
+    },
+    {
+      "pattern": "Synced",
+      "meaning": "Subgraph is caught up to chain tip"
+    },
+    {
+      "pattern": "Handling event",
+      "meaning": "Event handlers are executing successfully"
+    }
+  ]
+}

--- a/skills/subgraph-monitor-debug/evals/trigger-eval.json
+++ b/skills/subgraph-monitor-debug/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "what does the 'column specified more than once' error mean in my subgraph?", "should_trigger": true},
+  {"query": "what CLI flags does the goldsky subgraph log command accept?", "should_trigger": true},
+  {"query": "what causes subgraph stalled detection and auto-pause?", "should_trigger": true},
+  {"query": "I'm seeing a 'wasm trap' error in my subgraph logs, what does that mean?", "should_trigger": true},
+  {"query": "how do I check the status of my subgraph from the command line?", "should_trigger": true},
+  {"query": "what are common AssemblyScript mapping errors in subgraphs and their fixes?", "should_trigger": true},
+  {"query": "what does a store error mean in subgraph logs?", "should_trigger": true},
+  {"query": "I got a 524 timeout when deploying my subgraph from IPFS, what does that mean?", "should_trigger": true},
+  {"query": "when should I contact Goldsky support vs try to fix my subgraph issue myself?", "should_trigger": true},
+  {"query": "my specific subgraph my-nft-tracker/1.0.0 is broken, walk me through fixing it step by step", "should_trigger": false},
+  {"query": "help me deploy a new subgraph for my contract on Base", "should_trigger": false},
+  {"query": "how do I migrate my subgraph from TheGraph to Goldsky?", "should_trigger": false},
+  {"query": "how do I create a webhook for my subgraph?", "should_trigger": false},
+  {"query": "what error patterns should I look for in my turbo pipeline logs?", "should_trigger": false},
+  {"query": "what's the instant subgraph JSON config format?", "should_trigger": false}
+]


### PR DESCRIPTION
## Summary

- Adds **7 new subgraph skills** mirroring the existing Turbo pipeline skill set, giving the Goldsky agent full coverage of both products
- Includes interactive skills (builder, doctor, migrate), reference skills (config, lifecycle, monitor-debug), and an architecture skill that defaults to recommending Turbo pipelines
- Updates README.md and SKILLS.md to reflect expanded 17-skill coverage (up from 10)

## New Skills

| Skill | Type | Turbo Equivalent |
|-------|------|-----------------|
| `subgraph-builder` | Interactive | `turbo-builder` |
| `subgraph-doctor` | Interactive | `turbo-doctor` |
| `subgraph-migrate` | Interactive | *(unique — TheGraph/Alchemy migration)* |
| `subgraph-architecture` | Interactive | `turbo-architecture` |
| `subgraph-config` | Reference | `turbo-pipelines` |
| `subgraph-lifecycle` | Reference | `turbo-lifecycle` |
| `subgraph-monitor-debug` | Reference | `turbo-monitor-debug` |

## Supporting Files

- 4 instant subgraph JSON templates (single-contract, multi-contract, multi-chain, enrichments)
- Enrichments reference with all documented fields validated against Goldsky docs
- Chain slugs JSON: 41 mainnets + 7 testnets with common mistakes table
- Error patterns JSON: 9 categorized patterns with causes and solutions
- Trigger eval files for all 7 skills (15 queries each)

## Key Design Decisions

- **Pipeline-first bias** in `subgraph-architecture` — defaults to recommending Turbo pipelines unless the user specifically needs a GraphQL API, entity relationships, eth_call enrichments, or TheGraph migration
- **Same patterns as Turbo skills** — boundaries, mode detection (Bash vs reference), step-by-step workflows, cross-references between skills
- **Alchemy migration** includes Satsuma IPFS gateway tip (`--ipfs-gateway https://ipfs.satsuma.xyz`)

## Test plan

- [ ] Verify all 7 SKILL.md files have valid frontmatter (name + description)
- [ ] Test trigger queries manually in Claude Code (e.g., "deploy a subgraph for my NFT contract", "my subgraph is stuck", "should I use a subgraph or pipeline?")
- [ ] Verify cross-references: all `/subgraph-*` links in descriptions point to existing skills
- [ ] Validate chain slugs against https://docs.goldsky.com/chains/supported-networks
- [ ] Publish new plugin version with subgraph skills included

🤖 Generated with [Claude Code](https://claude.com/claude-code)