### PR TITLE
Use turbo inspect -p by default, drop TUI references

### DIFF
--- a/skills/turbo-builder/SKILL.md
+++ b/skills/turbo-builder/SKILL.md
@@ -148,8 +148,10 @@ goldsky turbo list
 Suggest running inspect to verify data flow:
 
 ```bash
-goldsky turbo inspect <pipeline-name>
+goldsky turbo inspect <pipeline-name> -p
 ```
+
+To filter to a specific node: `goldsky turbo inspect <pipeline-name> -n <node-name> -p`.
 
 Present a summary:
 
@@ -163,7 +165,7 @@ Present a summary:
 **Mode:** [streaming/job]
 
 **Next steps:**
-- Monitor with `goldsky turbo inspect <name>`
+- Verify data flow with `goldsky turbo inspect <name> -p`
 - Check logs with `goldsky turbo logs <name>`
 - Use /turbo-doctor if you run into issues
 ```

--- a/skills/turbo-operations/SKILL.md
+++ b/skills/turbo-operations/SKILL.md
@@ -99,36 +99,26 @@ goldsky turbo apply my-pipeline.yaml
 
 ## Monitoring Commands
 
-| Action                   | Command                                  |
-| ------------------------ | ---------------------------------------- |
-| List pipelines           | `goldsky turbo list`                     |
-| View live data           | `goldsky turbo inspect <name>`           |
-| Inspect specific node    | `goldsky turbo inspect <name> -n <node>` |
-| View logs                | `goldsky turbo logs <name>`              |
-| Follow logs              | `goldsky turbo logs <name> --follow`     |
-| Logs with timestamps     | `goldsky turbo logs <name> --timestamps` |
-| Last N lines             | `goldsky turbo logs <name> --tail N`     |
-| Logs since N seconds ago | `goldsky turbo logs <name> --since N`    |
+| Action                   | Command                                              |
+| ------------------------ | ---------------------------------------------------- |
+| List pipelines           | `goldsky turbo list`                                 |
+| View live data           | `goldsky turbo inspect <name> -p`                    |
+| Inspect specific node    | `goldsky turbo inspect <name> -n <node> -p`          |
+| View logs                | `goldsky turbo logs <name>`                          |
+| Follow logs              | `goldsky turbo logs <name> --follow`                 |
+| Logs with timestamps     | `goldsky turbo logs <name> --timestamps`             |
+| Last N lines             | `goldsky turbo logs <name> --tail N`                 |
+| Logs since N seconds ago | `goldsky turbo logs <name> --since N`                |
 
-## Live Inspect TUI Shortcuts
+## `goldsky turbo inspect` Flags
 
-| Key                     | Action               |
-| ----------------------- | -------------------- |
-| `Tab`/`→`, `Shift+Tab`/`←` | Next/prev tab    |
-| `1`-`9`                 | Jump to tab number   |
-| `j`/`k` / `↑`/`↓`     | Scroll               |
-| `g`/`Home`, `G`/`End`  | Top/bottom           |
-| `Page Up`/`Page Down`  | Scroll by page       |
-| `/` → `Enter`          | Search               |
-| `n` / `N`              | Next/prev match      |
-| `Esc`                   | Clear search         |
-| `d`                     | Toggle definition    |
-| `w`                     | Open web dashboard   |
-| `e`                     | Open web editor      |
-| `q` / `Ctrl+C`         | Quit                 |
-| `Shift` + mouse         | Select and copy text |
+| Flag                   | Short | Description                                                  |
+| ---------------------- | ----- | ------------------------------------------------------------ |
+| `--print`              | `-p`  | Print records to stdout                                      |
+| `--topology-node-keys` | `-n`  | Comma-separated node keys to filter (e.g. a transform name)  |
+| `--buffer-size`        | `-b`  | Max records to keep in buffer (default: 10000)               |
 
-The TUI automatically reconnects when the pipeline is updated, paused, resumed, or temporarily unavailable. It has a **30-minute timeout** before closing.
+Always use `-p`. Always include it in every `inspect` command you suggest.
 
 ### Log Analysis Script
 

--- a/skills/turbo-transforms/SKILL.md
+++ b/skills/turbo-transforms/SKILL.md
@@ -256,7 +256,7 @@ sinks:
 
 **"Missing primary_key"** — Every transform needs `primary_key`. Almost always use `id`.
 
-**"Column not found"** — Use `goldsky turbo inspect <pipeline> -n <source_node>` to see actual columns.
+**"Column not found"** — Use `goldsky turbo inspect <pipeline> -n <source_node> -p` to see actual columns.
 
 **Empty results from decoded events:**
 - Verify ABI JSON matches actual contract events
@@ -267,8 +267,7 @@ sinks:
 **Type mismatch in UNION ALL** — All branches need identical column counts and compatible types.
 
 ```bash
-# Inspect a specific transform's output
-goldsky turbo inspect <pipeline-name> -n <transform_name>
+goldsky turbo inspect <pipeline-name> -n <transform_name> -p
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Always recommend `goldsky turbo inspect <name> -p` in all skill examples
- Removed the TUI shortcuts section and TUI reconnect/timeout notes from turbo-operations
- Added `goldsky turbo inspect` flags reference (`-p`, `-n`, `-b`) with a clear directive to always use `-p`

🤖 Generated with [Claude Code](https://claude.com/claude-code)