### PR TITLE
Add stricter CLI validation to prevent hallucinated commands

### DIFF
--- a/agents/goldsky.md
+++ b/agents/goldsky.md
@@ -7,6 +7,25 @@ description: "Goldsky Turbo pipeline expert. Builds, debugs, and manages blockch
 
 You help users build, deploy, and manage Goldsky Turbo pipelines that stream blockchain data to their infrastructure.
 
+## CLI Command Validation Rule
+
+### MANDATORY: Verify Commands Before Suggesting
+
+Before recommending any `goldsky` CLI command, verify it exists. Reference the valid command list in `skills/turbo-operations/data/cli-commands.json`.
+
+**Valid `goldsky turbo` subcommands:** `apply`, `validate`, `list`, `delete`, `pause`, `resume`, `restart`, `inspect`, `logs`
+
+**Common hallucinations to AVOID:**
+- `goldsky turbo stop` - Use `pause` or `delete` instead
+- `goldsky turbo start` - Use `apply` or `resume` instead
+- `goldsky turbo run` - Use `apply` instead
+- `goldsky turbo update` - Use `apply` instead (it updates in place)
+- `goldsky turbo status` - Use `list` instead
+- `goldsky turbo deploy` - Use `apply` instead
+- `goldsky turbo create` - Use `apply` instead
+
+If you're unsure whether a command exists, check the `/turbo-operations` skill reference before suggesting it. Never guess CLI syntax.
+
 ## Pipeline YAML Validation Rule
 
 ### MANDATORY: Validate Before Presenting

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,6 +1,14 @@
 {
   "hooks": [
     {
+      "name": "cli-validation",
+      "description": "Validates Goldsky CLI commands and blocks invalid subcommands (like 'turbo stop') with helpful suggestions",
+      "type": "command",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/cli-validation.sh"
+    },
+    {
       "name": "pre-deploy-validate",
       "description": "Validates pipeline YAML before deploying with goldsky turbo apply",
       "type": "command",

--- a/hooks/scripts/cli-validation.sh
+++ b/hooks/scripts/cli-validation.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# cli-validation — Validates Goldsky CLI commands before execution
+#
+# PreToolUse hook for Bash commands. Intercepts `goldsky` commands and blocks
+# invalid subcommands (like `goldsky turbo stop`) with helpful suggestions.
+#
+# Input: JSON on stdin with { "tool_name": "Bash", "tool_input": { "command": "..." } }
+# Exit 0: Allow the command to proceed
+# Exit 2: Block the command (stderr is shown as the reason)
+
+set -euo pipefail
+
+# Read stdin
+INPUT=$(cat)
+
+# Extract the command from tool input
+COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+# Only intercept `goldsky` commands
+if ! echo "$COMMAND" | grep -qE '^goldsky[[:space:]]|[;&|]goldsky[[:space:]]'; then
+  exit 0
+fi
+
+# Extract the goldsky subcommand (e.g., "turbo stop" from "goldsky turbo stop my-pipeline")
+# Handle commands that might be chained with && or ;
+GOLDSKY_CMD=$(echo "$COMMAND" | grep -oE 'goldsky[[:space:]]+[a-z]+[[:space:]]+[a-z]+' | head -1)
+
+if [[ -z "$GOLDSKY_CMD" ]]; then
+  # Single subcommand (like "goldsky login") - allow
+  exit 0
+fi
+
+# Extract verb and subcommand (e.g., "turbo" and "stop")
+VERB=$(echo "$GOLDSKY_CMD" | awk '{print $2}')
+SUBCOMMAND=$(echo "$GOLDSKY_CMD" | awk '{print $3}')
+
+# Validate turbo subcommands
+if [[ "$VERB" == "turbo" ]]; then
+  case "$SUBCOMMAND" in
+    apply|validate|list|delete|pause|resume|restart|inspect|logs)
+      # Valid turbo commands
+      exit 0
+      ;;
+    stop)
+      echo "Hook: cli-validation" >&2
+      echo "" >&2
+      echo "Invalid command: goldsky turbo stop" >&2
+      echo "" >&2
+      echo "'stop' is not a valid Goldsky CLI command." >&2
+      echo "" >&2
+      echo "Did you mean:" >&2
+      echo "  - goldsky turbo pause <pipeline-name>   (temporarily stop, preserves state)" >&2
+      echo "  - goldsky turbo delete <pipeline-name>  (permanently remove pipeline)" >&2
+      exit 2
+      ;;
+    start)
+      echo "Hook: cli-validation" >&2
+      echo "" >&2
+      echo "Invalid command: goldsky turbo start" >&2
+      echo "" >&2
+      echo "'start' is not a valid Goldsky CLI command." >&2
+      echo "" >&2
+      echo "Did you mean:" >&2
+      echo "  - goldsky turbo apply <file.yaml>       (deploy a new pipeline)" >&2
+      echo "  - goldsky turbo resume <pipeline-name>  (resume a paused pipeline)" >&2
+      exit 2
+      ;;
+    run|execute)
+      echo "Hook: cli-validation" >&2
+      echo "" >&2
+      echo "Invalid command: goldsky turbo $SUBCOMMAND" >&2
+      echo "" >&2
+      echo "'$SUBCOMMAND' is not a valid Goldsky CLI command." >&2
+      echo "" >&2
+      echo "Did you mean:" >&2
+      echo "  - goldsky turbo apply <file.yaml>  (deploy a pipeline)" >&2
+      exit 2
+      ;;
+    update)
+      echo "Hook: cli-validation" >&2
+      echo "" >&2
+      echo "Invalid command: goldsky turbo update" >&2
+      echo "" >&2
+      echo "'update' is not a valid Goldsky CLI command." >&2
+      echo "" >&2
+      echo "Did you mean:" >&2
+      echo "  - goldsky turbo apply <file.yaml>  (re-applying updates the pipeline in place)" >&2
+      exit 2
+      ;;
+    status|info)
+      echo "Hook: cli-validation" >&2
+      echo "" >&2
+      echo "Invalid command: goldsky turbo $SUBCOMMAND" >&2
+      echo "" >&2
+      echo "'$SUBCOMMAND' is not a valid Goldsky CLI command." >&2
+      echo "" >&2
+      echo "Did you mean:" >&2
+      echo "  - goldsky turbo list  (list all pipelines with their status)" >&2
+      exit 2
+      ;;
+    deploy|create)
+      echo "Hook: cli-validation" >&2
+      echo "" >&2
+      echo "Invalid command: goldsky turbo $SUBCOMMAND" >&2
+      echo "" >&2
+      echo "'$SUBCOMMAND' is not a valid Goldsky CLI command." >&2
+      echo "" >&2
+      echo "Did you mean:" >&2
+      echo "  - goldsky turbo apply <file.yaml>  (deploy/create a pipeline from YAML)" >&2
+      exit 2
+      ;;
+    describe)
+      echo "Hook: cli-validation" >&2
+      echo "" >&2
+      echo "Invalid command: goldsky turbo describe" >&2
+      echo "" >&2
+      echo "'describe' is not a valid Goldsky CLI command." >&2
+      echo "" >&2
+      echo "Did you mean:" >&2
+      echo "  - goldsky turbo inspect <pipeline-name> -p  (view pipeline data)" >&2
+      echo "  - goldsky turbo list                        (list pipelines)" >&2
+      exit 2
+      ;;
+    *)
+      # Unknown subcommand - let the CLI handle it (might be a new command)
+      exit 0
+      ;;
+  esac
+fi
+
+# Validate secret subcommands
+if [[ "$VERB" == "secret" ]]; then
+  case "$SUBCOMMAND" in
+    list|create|update|delete|reveal)
+      exit 0
+      ;;
+    *)
+      # Unknown - let CLI handle it
+      exit 0
+      ;;
+  esac
+fi
+
+# Validate project subcommands
+if [[ "$VERB" == "project" ]]; then
+  case "$SUBCOMMAND" in
+    list|create|users)
+      exit 0
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+fi
+
+# Validate dataset subcommands
+if [[ "$VERB" == "dataset" ]]; then
+  case "$SUBCOMMAND" in
+    list)
+      exit 0
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+fi
+
+# All other goldsky commands - allow (let CLI handle unknown commands)
+exit 0

--- a/skills/turbo-operations/SKILL.md
+++ b/skills/turbo-operations/SKILL.md
@@ -7,6 +7,15 @@ description: "Turbo pipeline operations reference — lifecycle commands (pause,
 
 Lifecycle commands, monitoring, and error reference for running Turbo pipelines. This is a lookup reference — for interactive troubleshooting of a broken pipeline, use `/turbo-doctor`. For building new pipelines, use `/turbo-builder`.
 
+## Valid CLI Commands
+
+> **Important:** Only these `goldsky turbo` subcommands exist. Do not suggest others.
+>
+> `apply` | `validate` | `list` | `delete` | `pause` | `resume` | `restart` | `inspect` | `logs`
+>
+> Commands like `stop`, `start`, `run`, `update`, `status`, `deploy`, `create` do **not exist**.
+> See `data/cli-commands.json` for the full reference with syntax and common mistakes.
+
 ## Pipeline States
 
 | State     | Description                                  |

--- a/skills/turbo-operations/data/cli-commands.json
+++ b/skills/turbo-operations/data/cli-commands.json
@@ -1,0 +1,146 @@
+{
+  "description": "Goldsky CLI command reference. Use this to verify commands exist before suggesting them.",
+  "valid_commands": {
+    "turbo": {
+      "apply": {
+        "syntax": "goldsky turbo apply <file.yaml>",
+        "aliases": ["-f <file.yaml>", "--file <file.yaml>"],
+        "description": "Deploy or update a pipeline from YAML"
+      },
+      "validate": {
+        "syntax": "goldsky turbo validate <file.yaml>",
+        "aliases": ["-f <file.yaml>"],
+        "description": "Validate pipeline YAML without deploying"
+      },
+      "list": {
+        "syntax": "goldsky turbo list",
+        "description": "List all pipelines in the current project"
+      },
+      "delete": {
+        "syntax": "goldsky turbo delete <pipeline-name>",
+        "description": "Permanently delete a pipeline"
+      },
+      "pause": {
+        "syntax": "goldsky turbo pause <pipeline-name>",
+        "description": "Pause a streaming pipeline (preserves state)"
+      },
+      "resume": {
+        "syntax": "goldsky turbo resume <pipeline-name>",
+        "description": "Resume a paused pipeline"
+      },
+      "restart": {
+        "syntax": "goldsky turbo restart <pipeline-name>",
+        "flags": ["--clear-state"],
+        "description": "Restart pipeline pods"
+      },
+      "inspect": {
+        "syntax": "goldsky turbo inspect <pipeline-name> -p",
+        "flags": ["-p/--print", "-n/--topology-node-keys", "-b/--buffer-size"],
+        "description": "Interactive TUI to view live pipeline data"
+      },
+      "logs": {
+        "syntax": "goldsky turbo logs <pipeline-name>",
+        "flags": ["--follow", "--tail <N>", "--since <N>", "--timestamps"],
+        "description": "View pipeline logs"
+      }
+    },
+    "secret": {
+      "list": {
+        "syntax": "goldsky secret list",
+        "description": "List all secrets in the current project"
+      },
+      "create": {
+        "syntax": "goldsky secret create <name> --value <value>",
+        "description": "Create a new secret"
+      },
+      "update": {
+        "syntax": "goldsky secret update <name> --value <value>",
+        "description": "Update an existing secret"
+      },
+      "delete": {
+        "syntax": "goldsky secret delete <name>",
+        "description": "Delete a secret"
+      },
+      "reveal": {
+        "syntax": "goldsky secret reveal <name>",
+        "description": "Show the value of a secret"
+      }
+    },
+    "project": {
+      "list": {
+        "syntax": "goldsky project list",
+        "description": "List all projects"
+      },
+      "create": {
+        "syntax": "goldsky project create --name <name>",
+        "description": "Create a new project"
+      },
+      "users list": {
+        "syntax": "goldsky project users list",
+        "description": "List project members"
+      },
+      "users invite": {
+        "syntax": "goldsky project users invite --emails <email> --role <role>",
+        "description": "Invite a user to the project"
+      }
+    },
+    "dataset": {
+      "list": {
+        "syntax": "goldsky dataset list",
+        "description": "List available blockchain datasets"
+      }
+    }
+  },
+  "invalid_commands": {
+    "turbo stop": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo pause <pipeline-name>",
+      "note": "Use 'pause' to temporarily stop, or 'delete' to permanently remove"
+    },
+    "turbo start": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo apply <file.yaml>",
+      "note": "Use 'apply' to deploy a new pipeline, or 'resume' to restart a paused one"
+    },
+    "turbo run": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo apply <file.yaml>",
+      "note": "Pipelines are deployed with 'apply', not 'run'"
+    },
+    "turbo execute": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo apply <file.yaml>",
+      "note": "Pipelines are deployed with 'apply'"
+    },
+    "turbo update": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo apply <file.yaml>",
+      "note": "Re-running 'apply' with the same pipeline name updates it in place"
+    },
+    "turbo status": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo list",
+      "note": "Use 'list' to see pipeline statuses"
+    },
+    "turbo deploy": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo apply <file.yaml>",
+      "note": "Deployment is done with 'apply'"
+    },
+    "turbo create": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo apply <file.yaml>",
+      "note": "Pipelines are created by applying a YAML file"
+    },
+    "turbo info": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo list",
+      "note": "Use 'list' to see pipeline information"
+    },
+    "turbo describe": {
+      "reason": "Not a valid Goldsky CLI command",
+      "suggest_instead": "goldsky turbo inspect <pipeline-name> -p",
+      "note": "Use 'inspect -p' to see pipeline details and data"
+    }
+  }
+}


### PR DESCRIPTION
Adds multi-layered protection against the agent suggesting invalid Goldsky CLI commands like "goldsky turbo stop":

1. New PreToolUse hook (cli-validation.sh) that intercepts goldsky commands and blocks invalid subcommands with helpful suggestions
2. CLI commands reference file (cli-commands.json) with valid commands and common hallucinations mapped to correct alternatives
3. Updated agent instructions in goldsky.md with explicit validation rule and list of commands to avoid
4. Updated turbo-operations skill with valid command reference

Addresses feedback about AI hallucinating commands like "goldsky turbo stop" when the correct command is "goldsky turbo pause".

https://claude.ai/code/session_01YWTzn8QvPH6QmFfNAkA9op