### PR TITLE
fix: use record format for hooks config

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,28 +1,35 @@
 {
-  "hooks": [
-    {
-      "name": "pre-deploy-validate",
-      "description": "Validates pipeline YAML before deploying with goldsky turbo apply",
-      "type": "command",
-      "event": "PreToolUse",
-      "matcher": "Bash",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-deploy-validate.sh"
-    },
-    {
-      "name": "secret-check",
-      "description": "Verifies that all secret_name references in pipeline YAML exist before deploying",
-      "type": "command",
-      "event": "PreToolUse",
-      "matcher": "Bash",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/secret-check.sh"
-    },
-    {
-      "name": "post-deploy-inspect",
-      "description": "Suggests running goldsky turbo inspect after a successful pipeline deploy",
-      "type": "command",
-      "event": "PostToolUse",
-      "matcher": "Bash",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-deploy-inspect.sh"
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-deploy-validate.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/secret-check.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-deploy-inspect.sh"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes plugin load failure: `Invalid input: expected record, received array` at `hooks` path
- Converts `hooks.json` from an array of hook objects to a record keyed by event name (`PreToolUse`, `PostToolUse`), matching the Claude Code hooks schema
- All three existing hooks (pre-deploy-validate, secret-check, post-deploy-inspect) are preserved with identical behavior

## Test plan
- [ ] Install the plugin in Claude Code and run `/reload-plugins`
- [ ] Run `/doctor` and confirm no hook load errors for the goldsky plugin
- [ ] Trigger a `goldsky turbo apply` via Bash tool and verify PreToolUse hooks fire
- [ ] Verify PostToolUse hook fires after a deploy command

🤖 Generated with [Claude Code](https://claude.com/claude-code)