### PR TITLE
feat: add user-facing Compose skills (FOU-729)

### DIFF
--- a/skills/compose-doctor/SKILL.md
+++ b/skills/compose-doctor/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: compose-doctor
+description: "Diagnose and fix broken Goldsky Compose apps interactively. Triggers on: compose app in error state, crashlooping, not running, not processing tasks, cron not firing, HTTP trigger returning 500, onchain event listener missing events, wallet errors, gas sponsorship failures, 'No bundler provider available', manifest validation errors, bundling/esbuild failures, secret missing, 'You cannot use a smart wallet in local dev', 'Transaction Receipt failed with status'. Also use when the user mentions a Compose app name alongside a problem, even if they don't say 'compose' explicitly, if they're referring to `goldsky compose` commands (not `goldsky turbo` or `goldsky pipeline`). Runs `status`/`logs`/`secret list`/`wallet list` to identify root cause, and offers fixes. For building a new app from scratch, use /compose instead. For manifest field / CLI flag / API lookups without an active problem, use /compose-reference instead. Do NOT trigger on Turbo or Mirror pipeline problems."
+---
+
+# Compose Doctor
+
+Diagnose and fix broken Compose apps. Workflow-oriented: we walk through auth → app identification → status → logs → secrets → wallets → manifest → diagnosis → fix.
+
+## Boundaries
+
+- Diagnose and fix EXISTING Compose apps interactively.
+- Do not build new apps — use `/compose` for that.
+- Do not serve as a CLI/manifest reference — use `/compose-reference`.
+- For secrets creation/management mechanics, use `/secrets`. But DO check whether required secrets exist as part of diagnosis.
+- Do not handle Turbo pipeline problems — use `/turbo-doctor`.
+
+## Mode Detection
+
+Before running any commands, check if you have the `Bash` tool available:
+
+- **If Bash is available** (CLI mode): Execute commands directly and parse output.
+- **If Bash is NOT available** (reference mode): Output commands for the user to run. Ask them to paste the output back so you can analyze it and provide recommendations.
+
+## Diagnostic Workflow
+
+### Step 1 — Verify Auth
+
+`goldsky project list 2>&1`. If not logged in, use `/auth-setup`.
+
+### Step 2 — Identify the App
+
+`goldsky compose list`. Confirm the app exists and note its current status.
+
+### Step 3 — Check Status
+
+`goldsky compose status -n <app>` or `goldsky compose status -n <app> --json`.
+
+Possible statuses: RUNNING, PAUSED, ERROR, STARTING, STOPPED, PROVISIONING. Decision tree:
+
+- **RUNNING** but misbehaving → Step 4 (logs).
+- **ERROR** → Step 4 (logs) is the fastest path.
+- **PAUSED** → ask if intentional. `goldsky compose resume -n <app>` if not.
+- **STARTING** for >5 minutes → Step 4. (Use `.updated_at` from `--json` output to compute how long.)
+- **NOT_FOUND** → typo in the name? Or deployed to a different project / token.
+
+### Step 4 — Examine Logs
+
+`goldsky compose logs -n <app> --tail 200 --json 2>&1` (add `-f` to stream, `--level error,warn` to filter, `--since 1h` for a window, `--search <term>` for text match).
+
+**How to match errors:** scan the full log text (NDJSON `.message` field when `--json` is set) for **exact substring** against the first column of the error table below. Log lines include a `dashboard_url` attribute pointing to the specific run in the dashboard — surface it to the user alongside the diagnosis.
+
+### Step 5 — Check Secrets
+
+If logs show missing-secret or auth errors:
+
+```bash
+goldsky compose secret list -n <app>
+```
+
+Cross-reference against the manifest's `secrets:` array. Use `/secrets` or `goldsky compose secret set` to fix.
+
+### Step 6 — Check Wallets / Gas
+
+If logs show wallet or transaction errors:
+
+```bash
+goldsky compose wallet list -n <app>
+```
+
+Check whether the error is:
+
+- **"No bundler provider available for chain &lt;id&gt;"** → unsupported chain for gas sponsorship; either use a different chain or set `sponsorGas: false` and fund the EOA manually.
+- **"You cannot use a smart wallet in local dev…"** → switch to `compose dev --fork-chains` or use a BYO EOA wallet locally.
+- **"Transaction Receipt failed with status reverted"** → onchain revert. Open the `dashboard_url` from the log line — the run trace in the dashboard includes the decoded revert reason.
+
+### Step 7 — Check Manifest
+
+If logs show `Manifest validation failed: …`, the manifest was rejected at deploy time. Common causes are in the error table below.
+
+### Step 8 — Diagnose + Fix
+
+Present findings in this format:
+
+```
+## Diagnosis
+
+**App:** <name>
+**Status:** <status>
+**Root cause:** <one-line explanation>
+**Fix:** <one-line action, with exact command if possible>
+**Verify:** <how to confirm it worked>
+```
+
+**If the fix is mechanical** (secret set, manifest edit, redeploy), execute it and re-run Steps 3–4 to verify. **If the fix requires user input** (contract revert reason, funding decision, API key rotation), surface the diagnosis and stop.
+
+## Common Error Patterns
+
+| Log / error message                                                                                                 | Cause                                                              | Fix                                                                 |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| `Manifest validation failed: api_version is required for deployment.`                                               | Missing `api_version` at top of compose.yaml                       | Add `api_version: stable` (or a semver)                             |
+| `Manifest validation failed: api_version "<v>" is not valid.`                                                       | Bad version value                                                  | Use `stable`, `preview`, `canary`, or semver                        |
+| `Project name must start with a letter…`                                                                            | Manifest `name` violates RFC 1123                                  | lowercase, letters/numbers/hyphens, letter-start                    |
+| `<task>.name must start with a letter or underscore…`                                                               | Task name regex fail                                               | match `/^([a-zA-Z]\|_[a-zA-Z0-9])[a-zA-Z0-9_]*$/`                   |
+| `<task>.triggers[N].authentication must be either 'auth_token' or 'none'`                                           | HTTP trigger auth wrong                                            | set to one of the two values                                        |
+| `<task>.triggers[N].network must be in snake_case format`                                                           | onchain_event network name wrong case                              | `polygon_amoy`, `ethereum_mainnet` (snake_case)                     |
+| `<task>.triggers[N].contract must be a valid EVM address`                                                           | bad 0x address                                                     | check checksum + 40 hex chars                                       |
+| `<task>.triggers[N].ip_whitelist[N] must be a valid IP or CIDR`                                                     | malformed IP                                                       | fix format                                                          |
+| `Secret names must be in SCREAMING_SNAKE_CASE format`                                                               | bad secret name                                                    | `MY_SECRET`, not `my-secret`                                        |
+| `Secret name "<X>" in .env is reserved for the app's postgres database`                                             | secret clashes with hosted DB name (uppercased app name)           | rename the secret                                                   |
+| `The following secrets are referenced in the manifest but are not set in your local .env file`                      | local dev missing secret                                           | add to `.env` or `goldsky compose secret set --env local`           |
+| `Deploy blocked: required secrets are missing from cloud`                                                           | cloud secret missing                                               | `goldsky compose secret set` or `deploy --sync-env`                 |
+| `Task bundling failed: <msg>`                                                                                       | esbuild compile error                                              | fix the TS error in the task                                        |
+| `esbuild native binary crashed… architecture mismatch…`                                                             | arm/amd64 mismatch                                                 | rebuild image; `rm -rf ~/.cache/esbuild`                            |
+| `You cannot use a smart wallet in local dev unless you use chain forking.`                                          | Smart wallet in plain `compose dev`                                | `compose dev --fork-chains` or switch to a BYO EOA                  |
+| `No bundler provider available for chain <id>.`                                                                     | chain not supported by any bundler                                 | change chains, or set `sponsorGas: false`                           |
+| `Chain <id> is not supported by Alchemy's bundler.`                                                                 | forced Alchemy on wrong chain                                      | unset `BUNDLER_PROVIDER` env override                               |
+| `Transaction Receipt failed with status reverted`                                                                   | onchain revert                                                     | open `dashboard_url` for decoded revert reason                      |
+| `Cannot deserialize params: chain <id> not found`                                                                   | reorg replay for a chain missing in viem/chains                    | update the CLI / switch chains                                      |
+| `[Warning] onReorg is not supported for gas-sponsored transactions.`                                                | non-fatal warning                                                  | if reorg matters, switch to non-sponsored                           |
+| `[Warning] The 'nonce' parameter is being ignored for gas-sponsored transactions.`                                  | passing `nonce` to sponsored send                                  | remove the nonce override                                           |
+
+## Dashboard
+
+Every app has a dashboard page: `https://app.goldsky.com/<project_id>/dashboard/compose/<app-name>`. Every run has `…/runs/<run_id>`. When diagnosing, surface both links to the user.
+
+## When Bash is Not Available
+
+If you don't have the Bash tool, output the diagnostic commands for the user to run, but structure them clearly:
+
+1. Give one command at a time.
+2. Explain what to look for in the output.
+3. Based on their description of the output, proceed with the diagnosis.
+
+This is the fallback path — always prefer running commands directly when Bash is available.
+
+## Important Rules
+
+- Don't redeploy without reading logs first — the error is almost always already in there.
+- Pause (not delete) before investigating. `goldsky compose pause` stops task execution without tearing down state.
+- `--delete-database` on `compose delete` is irreversible — triple-check before running.
+- If a deploy is stuck at "Provisioning infra…" for >5 minutes on a first deploy, that's normal. For redeploys, it should be fast.
+
+## Related
+
+- **`/compose`** — Build a new Compose app or explain what Compose is.
+- **`/compose-reference`** — Manifest / CLI / TaskContext / codegen lookups.
+- **`/secrets`** — Generic secret management.
+- **`/auth-setup`** — Fix authentication.

--- a/skills/compose-reference/SKILL.md
+++ b/skills/compose-reference/SKILL.md
@@ -1,0 +1,453 @@
+---
+name: compose-reference
+description: "Use this skill when the user asks about a Goldsky Compose field, flag, type, or API shape — lookup reference for compose.yaml fields, every `goldsky compose` CLI flag, the TaskContext API (env, fetch, callTask, logEvent, evm, collection), wallet APIs (smart wallet, BYO EOA), gas sponsorship, contract codegen, dashboard URL, and pricing. Triggers on: 'compose.yaml fields', 'cron syntax for compose', 'http trigger auth', 'onchain_event format', 'TaskContext API', 'evm.wallet options', 'sponsorGas default', 'IWallet methods', 'Collection methods', 'compose codegen', 'compose pricing', 'compose status JSON output', 'goldsky compose flags'. Consult before suggesting a field, flag, or API shape — avoids hallucinating nonexistent options. For step-by-step building, use /compose. For debugging, use /compose-doctor. Do NOT trigger on Turbo, Mirror, Subgraphs, or Edge lookups — those belong to their own reference skills."
+---
+
+# Goldsky Compose Reference
+
+Reference for the `compose.yaml` manifest, the full `goldsky compose` CLI surface, the `TaskContext` API, wallets, gas sponsorship, contract codegen, the dashboard, and pricing. For interactive build flows use `/compose`; for debugging use `/compose-doctor`.
+
+> **Always validate the manifest before deploying.** `goldsky compose dev` catches schema errors fast.
+
+## Quick Reference
+
+Most common lookups:
+
+- **Manifest top-level / task / trigger fields** → [compose.yaml Manifest](#composeyaml-manifest)
+- **CLI flags** → [CLI Commands](#cli-commands)
+- **TaskContext shape, IWallet, Collection** → [TaskContext API](#taskcontext-api)
+- **Smart wallet vs BYO EOA, gas sponsorship defaults** → [Wallets — Deep Dive](#wallets--deep-dive)
+- **Contract codegen workflow** → [Contract Codegen](#contract-codegen-full-example)
+- **`--json` output shapes** → [CLI JSON Schemas](#cli-json-schemas)
+- **Dashboard URL** → [Dashboard](#dashboard)
+
+## compose.yaml Manifest
+
+### Top-level fields
+
+| Field         | Type                 | Required    | Notes                                                                                 |
+| ------------- | -------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| `name`        | string               | yes         | RFC 1123: lowercase, letters/numbers/hyphens, letter-start                            |
+| `api_version` | string               | deploy-only | semver (e.g. `0.1.0`) or `stable` / `preview` / `canary`                              |
+| `tasks`       | array                | yes         | Non-empty                                                                             |
+| `secrets`     | string[]             | no          | Names only — values set via `compose secret set`                                      |
+| `env`         | `{ local?, cloud? }` | no          | Each is `Record<string, string>`, flattened into `context.env`                        |
+
+### Task fields
+
+| Field          | Type     | Required | Notes                                                                                |
+| -------------- | -------- | -------- | ------------------------------------------------------------------------------------ |
+| `name`         | string   | yes      | `/^([a-zA-Z]\|_[a-zA-Z0-9])[a-zA-Z0-9_]*$/`                                          |
+| `path`         | string   | yes      | Relative path to the `.ts` task file                                                 |
+| `triggers`     | array    | yes      | One or more; at most one per type                                                    |
+| `retry_config` | object   | no       | `{ max_attempts, initial_interval_ms, backoff_factor }` — all three required when set |
+
+### Trigger types
+
+**cron**
+
+```yaml
+- type: cron
+  expression: "*/15 * * * *" # 5-field cron
+```
+
+**http**
+
+```yaml
+- type: http
+  authentication: auth_token # or "none"
+  ip_whitelist: ["1.2.3.4", "10.0.0.0/8"] # optional, IPv4/IPv6/CIDR
+```
+
+**onchain_event**
+
+```yaml
+- type: onchain_event
+  network: polygon_amoy # snake_case required
+  contract: "0xYourContractAddress" # 0x + 40 hex
+  events:
+    - "Transfer(address,address,uint256)" # viem signature strings, optional
+  dataset_version: "..." # optional
+```
+
+### Full manifest example
+
+```yaml
+name: my-app
+api_version: stable
+secrets:
+  - COINGECKO_API_KEY
+  - ORACLE_SIGNER_KEY
+env:
+  cloud:
+    LOG_LEVEL: info
+  local:
+    LOG_LEVEL: debug
+tasks:
+  - name: update_oracle
+    path: src/tasks/update-oracle.ts
+    retry_config:
+      max_attempts: 3
+      initial_interval_ms: 1000
+      backoff_factor: 2
+    triggers:
+      - type: cron
+        expression: "*/5 * * * *"
+  - name: manual_trigger
+    path: src/tasks/manual-trigger.ts
+    triggers:
+      - type: http
+        authentication: auth_token
+```
+
+## CLI Commands
+
+All commands accept `-t/--token` and `--api-server`; the `-n/--name` flag selects the app by name (falls back to `-m/--manifest`, then `./compose.yaml`).
+
+### Lifecycle
+
+| Command                            | Purpose                                                  | Key flags                                                                  |
+| ---------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `compose init [name]`              | Scaffold new app                                         | (interactive)                                                              |
+| `compose dev`                      | Run locally (alias: `start`)                             | `--fork-chains`, `--cloud`                                                 |
+| `compose deploy`                   | Bundle + upload to cloud                                 | `-m`, `-t`, `-f`, `--sync-env`                                             |
+| `compose status`                   | Show runtime status                                      | `-n`, `--json`                                                             |
+| `compose list`                     | List all apps                                            | `--json`                                                                   |
+| `compose pause`                    | Pause                                                    | `-n`                                                                       |
+| `compose resume`                   | Resume                                                   | `-n`                                                                       |
+| `compose delete`                   | Delete (type-to-confirm; `--force` for CI)               | `-n`, `--force`, `--delete-database`                                       |
+| `compose logs`                     | View / tail logs                                         | `-f`, `--tail`, `--level`, `--search`, `--since`, `--max-lines`, `--json`  |
+| `compose clean`                    | Wipe local `.compose/stage.db`                           | `-f`                                                                       |
+| `compose update`                   | Re-download the compose binary                           | `--preview`                                                                |
+| `compose callTask <name> <json>`   | POST payload to a local task                             |                                                                            |
+
+### Secrets
+
+| Command                                                                              | Purpose                  |
+| ------------------------------------------------------------------------------------ | ------------------------ |
+| `compose secret set --name X --value Y [--env local\|cloud] [--redeploy]`            | Set a secret             |
+| `compose secret delete --name X [--env local\|cloud]`                                | Delete                   |
+| `compose secret list [--env local\|cloud]`                                           | List                     |
+| `compose secret sync`                                                                | Upload all of `.env` to cloud |
+
+### Wallets
+
+| Command                                               | Purpose                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------- |
+| `compose wallet create --name X [--env local\|cloud]` | Create managed wallet; prints address                                  |
+| `compose wallet list`                                 | Table: name, address, type (privy / private_key / tevm), created_at    |
+
+### Codegen
+
+`compose codegen` — parse all `src/contracts/*.json` ABIs, write `.compose/generated/index.ts` and `.compose/types.d.ts`. Runs automatically inside `compose init`, `compose dev`, and during deploy.
+
+## TaskContext API
+
+`main(context: TaskContext, params?: Record<string, unknown>): Promise<unknown>` receives:
+
+```ts
+type TaskContext = {
+  env: Record<string, string>;
+  fetch: FetchFn;
+  callTask: <Args, T>(name: string, args: Args, retryConfig?: RetryConfig) => Promise<T>;
+  logEvent: (event: { code: string; message: string; data?: unknown }) => Promise<void>;
+  evm: {
+    chains: Record<string, Chain>;              // re-exported from viem/chains
+    wallet: (config: WalletConfig) => Promise<IWallet>;
+    decodeEventLog: <T>(abi: AbiItem[], log: EventLog) => Promise<T>;
+    contracts: Record<string, ContractClass>;   // populated by codegen
+  };
+  collection: <T>(name: string, indexes?: string[]) => Promise<Collection<T>>;
+};
+```
+
+**No `logger` or `secrets` namespace.** Secrets flatten into `context.env`. Use `console.log` for free-form logging, `logEvent` for structured events.
+
+### `fetch` (overloads)
+
+```ts
+interface FetchFn {
+  <T>(url: string, retryConfig?: RetryConfig): Promise<T | undefined>;
+  <T>(url: string, body: unknown, retryConfig?: RetryConfig): Promise<T | undefined>;
+}
+```
+
+- `body` is serialized as JSON and sent as POST. Omit `body` for GET.
+- Response is JSON-parsed; returns `undefined` when the body isn't JSON.
+- Not `window.fetch` — use this, not native `fetch`.
+
+### `callTask`
+
+```ts
+callTask<Args, T>(name: string, args: Args, retryConfig?: RetryConfig): Promise<T>
+```
+
+- `T` is whatever the callee returns. A `void`-returning task resolves to `undefined`.
+- Use for task-to-task invocation (parent/child patterns).
+
+### `RetryConfig`
+
+```ts
+type RetryConfig = {
+  max_attempts: number;         // ≥0
+  initial_interval_ms: number;  // >0
+  backoff_factor: number;       // >0
+};
+```
+
+No defaults — supply all three when you pass a `retryConfig`. Without it, the task runs once and any thrown error surfaces to the run record.
+
+### `EventLog` (for `decodeEventLog` and `onchain_event` triggers)
+
+```ts
+type EventLog = {
+  address: Address;     // "0x…"
+  topics: Hex[];        // indexed topics
+  data: Hex;            // non-indexed data
+  blockNumber?: bigint;
+  transactionHash?: Hex;
+  logIndex?: number;
+};
+```
+
+For `onchain_event`-triggered tasks, `params` contains `{ log: EventLog }` plus chain-specific metadata. `decodeEventLog(abi, params.log)` returns the decoded struct.
+
+### IWallet
+
+```ts
+interface IWallet {
+  readonly name: string;
+  readonly address: Address;
+  writeContract(
+    chain: Chain,
+    address: Address,
+    signatureOrAbi: string | AbiItem,
+    args?: unknown[],
+    options?: WriteOptions,
+  ): Promise<TxResult>;
+  readContract(
+    chain: Chain,
+    address: Address,
+    signatureOrAbi: string | AbiItem,
+    args?: unknown[],
+  ): Promise<unknown>;
+  sendTransaction(
+    chain: Chain,
+    to: Address,
+    value: bigint,
+    data?: Hex,
+    options?: WriteOptions,
+  ): Promise<TxResult>;
+  simulate(
+    chain: Chain,
+    address: Address,
+    signatureOrAbi: string | AbiItem,
+    args?: unknown[],
+  ): Promise<SimulateResult>;
+  getBalance(chain: Chain): Promise<bigint>;
+}
+
+type WriteOptions = {
+  confirmations?: number;
+  onReorg?: { action: { type: "replay" | "skip" }; depth: number };
+  retryConfig?: RetryConfig;
+  gas?: bigint;
+  gasPrice?: bigint;
+};
+
+type TxResult = {
+  hash: Hex;
+  userOpHash?: Hex;     // only for sponsored transactions
+  chainId: number;
+  blockNumber?: bigint; // present after mining
+};
+
+type SimulateResult = {
+  success: boolean;
+  result?: unknown;
+  error?: string;
+};
+```
+
+### Collection
+
+```ts
+interface Collection<T> {
+  insertOne(doc: T): Promise<void>;
+  findOne(filter: Filter<T>): Promise<T | null>;
+  findMany(filter: Filter<T>, options?: { limit?: number; skip?: number }): Promise<T[]>;
+  getById(id: string): Promise<T | null>;
+  setById(id: string, doc: T, opts?: { upsert?: boolean }): Promise<void>; // upsert defaults true
+  deleteById(id: string): Promise<void>;
+  drop(): Promise<void>;
+}
+```
+
+Filter operators: `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$ne`, `$nin`, `$exists`. Equality: `{ field: value }`.
+
+## CLI JSON Schemas
+
+For agents parsing `--json` output:
+
+### `compose status -n <app> --json`
+
+```json
+{
+  "name": "my-app",
+  "status": "RUNNING",
+  "created_at": 1771630350411,
+  "updated_at": 1774473580871
+}
+```
+
+`status` is one of `RUNNING | PAUSED | ERROR | STARTING | STOPPED | PROVISIONING`. Timestamps are ms epoch.
+
+### `compose list --json`
+
+```json
+[
+  { "name": "my-app", "status": "RUNNING", "created_at": 1771630350411, "updated_at": 1774473580871 }
+]
+```
+
+### `compose logs --json`
+
+NDJSON (one object per line):
+
+```json
+{"timestamp":"2026-04-20T10:00:00Z","level":"info","message":"...","dashboard_url":"https://app.goldsky.com/<project_id>/dashboard/compose/<app>/runs/<run_id>"}
+```
+
+### `compose secret list -n <app> --json`
+
+```json
+[{ "name": "MY_SECRET" }]
+```
+
+Values are never returned.
+
+### `compose wallet list --json`
+
+```json
+[{ "name": "updater", "address": "0x...", "type": "privy", "created_at": 1771630350411 }]
+```
+
+`type` is one of `privy` (smart wallet), `private_key` (BYO EOA), `tevm` (local forked).
+
+## Wallets — Deep Dive
+
+### Smart wallet (managed, Privy-backed)
+
+```ts
+const w = await evm.wallet({ name: "my-oracle" }); // sponsorGas defaults TRUE
+```
+
+Created cloud-side by Privy. Address is persisted. **Gas-sponsored by default.** **Cannot be used in plain local dev** — throws `"You cannot use a smart wallet in local dev unless you use chain forking."` Use `compose dev --fork-chains` or switch to a BYO EOA for local iteration.
+
+### BYO EOA (private key)
+
+```ts
+const w = await evm.wallet({
+  privateKey: env.MY_KEY,
+  name: "my-pk-wallet",       // optional; defaults to the derived address
+  sponsorGas: true,           // DEFAULTS TO FALSE — opt in explicitly
+});
+```
+
+Works in both cloud and local. When `sponsorGas: true`, the wallet configures EIP-7702 delegation per chain on first use, then submits UserOperations through a sponsored bundler.
+
+## Gas Sponsorship
+
+Bundler fallback order: **Alchemy → Pimlico → Gelato**. Override via `BUNDLER_PROVIDER=<alchemy|pimlico|gelato>` env var.
+
+### Supported chains
+
+See the Goldsky docs chains page for the current list (don't hardcode — this changes). Highlights include Ethereum, Base, Arbitrum, Optimism, Polygon, Unichain, Monad (mainnet + testnet), MegaETH testnet, Lisk, Linea, Scroll, Avalanche, Blast, BNB, Celo, Zora, Sonic, Worldchain, plus major Sepolia testnets and Polygon Amoy.
+
+### Error on unsupported chain
+
+```
+No bundler provider available for chain <id>. Providers: alchemy: chain not supported; pimlico: missing keys (PIMLICO_API_KEY); gelato: …
+```
+
+Either use a supported chain or set `sponsorGas: false` and fund the EOA manually.
+
+### Caveats
+
+- `onReorg` is **not** supported for gas-sponsored transactions (warning logged, not fatal).
+- Passing a custom `nonce` to a sponsored `sendTransaction` is ignored (ERC-4337 smart wallets use a different nonce structure).
+
+## Contract Codegen (full example)
+
+### Input
+
+Drop ABI JSON files into `src/contracts/`:
+
+```
+src/contracts/
+├── ERC20.json
+└── PriceFeed.json
+```
+
+**Accepted ABI shapes:** bare ABI array (`[{ "type": "function", ... }, ...]`), or wrapped object (`{ "abi": [...] }`), or a Foundry/Hardhat artifact (the generator extracts the `abi` field). The filename (without extension) becomes the generated class name.
+
+### Generate
+
+```bash
+goldsky compose codegen
+```
+
+(Also runs automatically during `init`, `dev`, and `deploy`.)
+
+### Output
+
+`.compose/generated/index.ts` exports a class per ABI. `.compose/types.d.ts` declares ambient types under the `compose` path alias (referenced in the scaffolded `tsconfig.json`).
+
+### Consume in a task
+
+```ts
+import type { TaskContext } from "compose";
+
+export async function main({ evm, env }: TaskContext) {
+  const PriceFeed = evm.contracts.PriceFeed;
+  const feed = new PriceFeed(evm.chains.ethereum, env.FEED_ADDRESS);
+  const price = await feed.latestAnswer();
+  return { price: price.toString() };
+}
+```
+
+Classes are exposed under `context.evm.contracts.<Name>`. Codegen names ending in `Class` (e.g. `ERC20Class`) are exposed as `ERC20` at runtime.
+
+## Supported Chains
+
+`context.evm.chains` is re-exported from `viem/chains`. Any chain viem knows, you can address as `evm.chains.<name>` (e.g. `evm.chains.polygonAmoy`, `evm.chains.monadTestnet`, `evm.chains.baseSepolia`). For **gas sponsorship** specifically, see the Gas Sponsorship section — sponsorship is a subset of viem's chain list.
+
+## Dashboard
+
+URL pattern:
+
+```
+https://app.goldsky.com/<project_id>/dashboard/compose/<app-name>
+https://app.goldsky.com/<project_id>/dashboard/compose/<app-name>/runs/<run_id>
+```
+
+The dashboard shows status, secrets, logs, and per-run traces. Log lines include a `dashboard_url` attribute in their metadata so agents can link the user directly to the relevant run.
+
+## Pricing
+
+Compose is in **Beta**. Pricing is **enterprise-only** — schedule a call with Goldsky to discuss your use case. Source: https://goldsky.com/pricing (Compose section).
+
+Internally, usage is tracked across three metered dimensions:
+
+- **Function calls** (`compose_function_calls`) — number of task invocations.
+- **Worker hours** (`compose_worker_hours`) — runtime consumed.
+- **Gas spend** (`compose_gas_spend`) — gas paid for sponsored transactions.
+
+These metrics drive enterprise-tier billing; per-unit prices are set per contract, not published.
+
+## Related
+
+- **`/compose`** — Build a new app or explain what Compose is.
+- **`/compose-doctor`** — Diagnose and fix broken apps.
+- **`/auth-setup`** — `goldsky login` help.
+- **`/secrets`** — General secret management.

--- a/skills/compose/SKILL.md
+++ b/skills/compose/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: compose
+description: "Use this skill when the user asks about Goldsky Compose — the offchain-to-onchain TypeScript framework for onchain oracles, keepers, circuit breakers, and cross-chain automation. Triggers on: 'goldsky compose', 'compose.yaml', 'compose deploy/init/dev', 'compose task', 'cron task onchain', 'sponsored gas', 'writeContract from TypeScript', 'build a price oracle', 'resolve prediction market', 'onchain event listener', 'HTTP-triggered task', 'smart wallet'. Also use when the user wants to run TypeScript against EVM chains with managed gas, schedule onchain writes via cron, react to onchain events, or deploy a serverless task with secrets and a smart wallet. For debugging a broken app, use /compose-doctor. For manifest/CLI/API lookups, use /compose-reference. Do NOT trigger on Goldsky Turbo, Mirror, Subgraphs, Edge, or Datasets — those belong to their respective skills."
+---
+
+# Goldsky Compose
+
+Goldsky Compose is the offchain-to-onchain framework for high-stakes systems. Write TypeScript **tasks** that run in verifiable sandboxes — triggered by cron, HTTP, or onchain events — with smart wallets, gas sponsorship, and durable collections. Typical use cases: custom price oracles, keepers, circuit breakers, prediction-market resolvers, cross-chain automation, identity/attestation flows, and notifications.
+
+## Boundaries
+
+- Build new Compose apps or explain what Compose is. For debugging a broken app, use `/compose-doctor`.
+- Do not serve as a manifest / CLI / API reference. For field syntax, flag lookups, or TaskContext shapes, use `/compose-reference`.
+- For `goldsky login`, use `/auth-setup`. For generic secret management, use `/secrets`.
+
+## Mode Detection
+
+Before running commands, check if the `Bash` tool is available:
+
+- **If Bash is available** (CLI mode): use the Walk Me Through It section below to execute commands directly and parse output.
+- **If Bash is NOT available** (reference mode): the Quickstart below is enough for most chatbot Q&A. For step-by-step help, output one command at a time and ask the user to paste output back.
+
+## What Compose Does
+
+- Serverless TypeScript runtime for EVM-aware tasks.
+- Three trigger types: **cron**, **HTTP**, **onchain_event**.
+- **Smart wallets** (managed by Goldsky, gas-sponsored by default) or **BYO EOA** wallets (user-supplied private key).
+- Built-in secrets, collections (durable storage), typed contract bindings via codegen.
+- `compose dev` for hot-reload local dev; `compose deploy` to ship; `compose logs -f` to tail.
+
+## Out of Scope (for this skill)
+
+- **Deploying the target onchain contract.** Compose writes to contracts that already exist. If the user needs one deployed, direct them to Foundry / Hardhat first and resume here once they have the address + ABI.
+- **Sourcing a contract ABI.** The user provides the ABI JSON file; this skill does not fetch from Etherscan / Sourcify.
+- **Funding a BYO EOA.** If sponsorship is off, the user must fund the address out-of-band.
+
+## Quickstart
+
+### Install
+
+```bash
+curl https://goldsky.com | sh
+goldsky login
+```
+
+### Scaffold + deploy
+
+```bash
+goldsky compose init <app-name>          # scaffolds a Bitcoin-oracle example
+cd <app-name>
+goldsky compose dev                      # hot-reload local server on :4000
+goldsky compose deploy                   # bundle + upload to cloud
+goldsky compose status                   # expect RUNNING
+goldsky compose logs -f                  # stream logs
+```
+
+### Minimal `compose.yaml` + task
+
+```yaml
+# compose.yaml
+name: my-oracle
+api_version: stable
+secrets:
+  - ORACLE_ADDRESS
+tasks:
+  - name: hourly_update
+    path: src/tasks/hourly-update.ts
+    triggers:
+      - type: cron
+        expression: "0 * * * *"
+```
+
+```ts
+// src/tasks/hourly-update.ts
+import type { TaskContext } from "compose";
+
+export async function main({ evm, env, logEvent }: TaskContext) {
+  const wallet = await evm.wallet({ name: "updater" });
+  const tx = await wallet.writeContract(
+    evm.chains.polygonAmoy,
+    env.ORACLE_ADDRESS,
+    "update(uint256)",
+    [BigInt(Date.now())],
+    { confirmations: 3, onReorg: { action: { type: "replay" }, depth: 200 } },
+  );
+  await logEvent({ code: "updated", message: "ok", data: { hash: tx.hash } });
+}
+```
+
+## Core Concepts
+
+### Tasks
+
+A task is a TypeScript file exporting `async function main(context, params?)`. Each task declares one or more triggers in `compose.yaml`.
+
+### Triggers
+
+| Type            | Fires on                     | Key config                                                                |
+| --------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `cron`          | schedule                     | `expression` (5-field cron)                                               |
+| `http`          | HTTP POST to `/tasks/<name>` | `authentication: auth_token \| none`, optional `ip_whitelist`             |
+| `onchain_event` | decoded log                  | `network` (snake_case), `contract`, `events` (viem signature strings)     |
+
+### TaskContext
+
+Every task receives `{ env, fetch, callTask, logEvent, evm, collection }`. Secrets flatten into `context.env` — there is no separate `secrets` namespace. See `/compose-reference` for the full API.
+
+### Wallets
+
+Two kinds:
+
+- **Smart wallet (managed)** — `evm.wallet({ name: "updater" })`. Hosted by Goldsky, gas-sponsored by default. Cannot be used in plain local dev — use `compose dev --fork-chains` or switch to a BYO EOA.
+- **BYO EOA (private key)** — `evm.wallet({ privateKey: env.MY_KEY, sponsorGas: true })`. **Gas sponsorship is OFF by default** for BYO EOA wallets; opt in explicitly.
+
+### Secrets & env
+
+List names in the manifest's `secrets:` array, set values with `goldsky compose secret set --name X --value Y` (or `compose secret sync` to upload `.env`). Values flatten into `context.env` at runtime. Names must be SCREAMING_SNAKE_CASE.
+
+### Gas sponsorship
+
+Bundler fallback: Alchemy → Pimlico → Gelato. Broad EVM coverage (mainnet + testnet); see `/compose-reference` for the chain list and caveats.
+
+### Dashboard
+
+Every deployed app has a dashboard at `https://app.goldsky.com/<project_id>/dashboard/compose/<app-name>`.
+
+## Capability Tour
+
+Inline worked examples. Start with **Cron → writeContract** if you don't know which applies.
+
+### Cron → writeContract (the scaffold default)
+
+Exactly the minimal task above — a cron task that writes to a contract every hour, with `onReorg: replay` for safety.
+
+### HTTP task with auth_token
+
+```yaml
+# compose.yaml (task entry)
+- name: manual_fire
+  path: src/tasks/manual-fire.ts
+  triggers:
+    - type: http
+      authentication: auth_token
+```
+
+```ts
+// src/tasks/manual-fire.ts
+import type { TaskContext } from "compose";
+
+export async function main({ logEvent }: TaskContext, params: { amount: number }) {
+  await logEvent({ code: "fired", message: "manual", data: params });
+  return { ok: true, received: params.amount };
+}
+```
+
+Invoke: `curl -X POST -H "Authorization: Bearer $TOKEN" -d '{"amount": 42}' https://<app-url>/tasks/manual_fire`.
+
+### Onchain event listener
+
+```yaml
+- name: on_transfer
+  path: src/tasks/on-transfer.ts
+  triggers:
+    - type: onchain_event
+      network: polygon_amoy
+      contract: "0xYourContract"
+      events:
+        - "Transfer(address,address,uint256)"
+```
+
+```ts
+import type { TaskContext } from "compose";
+
+export async function main(
+  { evm, logEvent }: TaskContext,
+  params: { log: { topics: string[]; data: string; address: string } },
+) {
+  const decoded = await evm.decodeEventLog(
+    [{ type: "event", name: "Transfer", inputs: [/* ABI inputs */] }],
+    params.log,
+  );
+  await logEvent({ code: "transfer", message: "seen", data: decoded });
+}
+```
+
+### Smart wallet + sponsored writeContract
+
+```ts
+const wallet = await evm.wallet({ name: "my-oracle" }); // sponsorGas defaults TRUE
+const tx = await wallet.writeContract(
+  evm.chains.base,
+  env.FEED_ADDRESS,
+  "setPrice(uint256)",
+  [1234n],
+);
+```
+
+### BYO EOA with sponsored gas (opt-in)
+
+```ts
+const wallet = await evm.wallet({
+  privateKey: env.MY_KEY,
+  sponsorGas: true, // MUST opt in; defaults FALSE
+});
+```
+
+### Durable storage (collection)
+
+```ts
+const runs = await collection<{ id: string; ts: number }>("runs");
+await runs.setById("latest", { id: "latest", ts: Date.now() });
+const recent = await runs.findOne({ ts: { $gt: Date.now() - 86_400_000 } });
+```
+
+### Typed contracts via codegen
+
+Drop an ABI into `src/contracts/Oracle.json`. After `goldsky compose codegen` (or any `init`/`dev`/`deploy`), the contract is available as `evm.contracts.Oracle`. Full workflow in `/compose-reference`.
+
+## Walk Me Through It
+
+Only activate when Bash is available.
+
+### Step 1 — Verify auth
+
+`goldsky project list 2>&1`. If not logged in, use `/auth-setup`.
+
+### Step 2 — Derive first, ask only the ambiguous
+
+From the user's natural-language prompt, **derive** as many of these as possible before asking:
+
+- **Trigger type** — "every 5 minutes" → cron; "on each Transfer" → onchain_event; "when I call it" → http.
+- **Chain** — named (`polygonAmoy`, `base`) → use it; "testnet" with no name → ask.
+- **Read vs write** — "track", "index", "notify" → read; "update", "set", "submit" → write.
+- **Wallet** — write + sponsored gas → smart wallet (default); user supplied a PK → BYO EOA with `sponsorGas: true`.
+- **Secrets** — any external API key or contract address → needs a secret entry.
+- **`api_version`** — default to `stable` unless user asks otherwise.
+
+Only ask the user for fields you couldn't derive.
+
+### Step 3 — Scaffold
+
+`goldsky compose init <name>`. Inspect the scaffold to see the canonical file layout.
+
+### Step 4 — Edit the manifest
+
+Replace the scaffold's task block with the derived trigger + secret list. Use the YAML snippets from the Capability Tour above.
+
+### Step 5 — Write the task
+
+Replace the scaffold's task file with logic derived from the prompt. Use the capability-tour snippet for the chosen trigger as the starting point.
+
+### Step 6 — Wire secrets and wallets
+
+- Every name in `compose.yaml`'s `secrets:` → `goldsky compose secret set --name X --value Y` (or add to `.env` + `compose secret sync`).
+- Smart wallet → `goldsky compose wallet create --name <name>`. Then `wallet list` to get the address and share with the user (they may need to grant it onchain permissions on the target contract).
+- BYO EOA → add the private key to `.env` (SCREAMING_SNAKE_CASE name), reference via `env.X` in the task.
+
+### Step 7 — Local dev
+
+`goldsky compose dev`. Smart wallets require `--fork-chains` locally; use a BYO EOA if the user wants to test against a live testnet. For HTTP tasks: `goldsky compose callTask <name> '<json>'` in another terminal.
+
+### Step 8 — Deploy
+
+`goldsky compose deploy`. Expect progress: "Building Dedicated app database…" → "Deploying app…" → "Provisioning infra…" (can take a minute or two on first deploy).
+
+### Step 9 — Verify
+
+```bash
+goldsky compose status --json     # expect .status == "RUNNING"
+goldsky compose logs -f           # expect app-specific log lines
+```
+
+Share the dashboard URL: `https://app.goldsky.com/<project_id>/dashboard/compose/<app-name>`.
+
+## Important Rules
+
+- **Smart wallets don't work in plain `compose dev`** — use `--fork-chains` or switch to a BYO EOA for local iteration.
+- **BYO EOA gas sponsorship defaults to FALSE** — opt in explicitly with `sponsorGas: true`.
+- **Cloud secrets are not synced from `.env` automatically.** Run `compose secret sync` or `compose deploy --sync-env`.
+- **Secret names must be SCREAMING_SNAKE_CASE.**
+- **`api_version` is required for deploy.** Default to `stable`.
+
+## Related
+
+- **`/compose-doctor`** — Diagnose and fix broken Compose apps.
+- **`/compose-reference`** — Manifest, CLI, TaskContext API, wallets, gas sponsorship, codegen.
+- **`/auth-setup`** — `goldsky login` walkthrough.
+- **`/secrets`** — Generic secret management.


### PR DESCRIPTION
## Summary

Adds three sibling skills under `skills/` to give the Goldsky chatbot and developer agents coverage of **Goldsky Compose** — the offchain-to-onchain TypeScript framework. Mirrors the `turbo-builder` / `turbo-doctor` split, sized to match Sophia's `edge/SKILL.md` exemplar (PR #21).

- **`skills/compose/`** (288 lines) — concept + quickstart + inline capability tour + hybrid interactive walkthrough gated by Mode Detection.
- **`skills/compose-doctor/`** (149 lines) — diagnostic workflow (auth → identify → status → logs → secrets → wallets → manifest → diagnose) + 20-row error pattern table mapped to real runtime messages.
- **`skills/compose-reference/`** (453 lines) — `compose.yaml` manifest, every `goldsky compose` CLI subcommand + flag, full `TaskContext` API shape (including `TxResult`, `EventLog`, `RetryConfig`, `IWallet`, `Collection`), wallets, gas sponsorship bundler fallback, codegen workflow with ABI shape spec, dashboard URL pattern, and `--json` output schemas for agent parsers.

### Key design decisions

- **Three skills, not one or five.** Edge is narrower (1 skill), Turbo is broader (5). Compose sits between — 3 is the right cut.
- **Frontmatter descriptions target ≤1,024 chars** (Agent Skills open-standard cap) for chatbot-loader portability. All three come in under: compose 878, compose-doctor 985, compose-reference 924.
- **`compose-reference` doubles as an agent-parsing spec.** Every TaskContext type is fully specified (no hand-waved shapes), every `--json` output has a schema. Agents writing Compose task code against this skill alone should produce compiling TypeScript.
- **Cross-skill sync matrix** lives in the origin plan — future changes to triggers / CLI flags / TaskContext need coordinated edits across the three files.

### Origin

- Linear: [FOU-729](https://linear.app/goldsky/issue/FOU-729/add-user-facing-compose-agent-skills-to-repo)
- Slack thread where Sophia raised the gap: https://goldskyio.slack.com/archives/C0A7B2RBEKY/p1775766368090629
- Adam committed "done by end of April" in the Linear thread on 2026-04-16.

## Validation performed

- ✅ `npx skills add . --list` loads all 16 skills (was 13 + these 3) cleanly; descriptions render.
- ✅ Frontmatter: exactly `name` + `description`, matching the 13 existing skills.
- ✅ Descriptions under 1,024-char cap (Agent Skills open standard).
- ✅ Cross-skill links use backtick + slash (`\`/compose-doctor\``) per repo convention.
- ✅ No "project" vs "app" drift, no wallet-terminology drift (smart wallet / BYO EOA), no invalid env names.
- ✅ All factual claims traced to citations in `compose/src/cli.ts`, `src/lib/validation.ts`, `src/task-manager/task-types.ts`, `src/context/config/evm/*.ts`.

## Manual validation to run post-merge

- [ ] Chatbot test: ask "what is Goldsky Compose?" — confirm it no longer hallucinates (Sophia's original reproduction).
- [ ] Trigger-phrase sanity check — \"deploy a Compose app\" → `/compose`; \"my Compose app is crashlooping\" → `/compose-doctor`; \"what's the shape of `compose status --json`?\" → `/compose-reference`.
- [ ] Turbo questions don't accidentally pull Compose in.

## Out of scope / follow-ups

- **`compose exec`** (FOU-730) — in a draft PR, not merged. Once it lands, add a CLI row to `compose-reference` (or a capability-tour entry in `compose` if it becomes a primary workflow). Defer placement decision to that PR.
- **FOU-295** (Agent.md per `compose init` template) — orthogonal; the scaffold can eventually drop a local SKILL.md pointing users' agents at this repo.
- README Quick Start / skills-count badge — not touched, matching PR #21 precedent (Edge also shipped without README edits).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — these are documentation files consumed by the chatbot and agents at load time. No runtime impact, no production data touched.

---

cc @sophialittlejohn for review (product/framing) and @benny for content accuracy on runtime behavior.

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)