### PR TITLE
turbo skills: harden multi-sink guidance to prevent per-destination pipeline split

### DIFF
--- a/skills/turbo-builder/SKILL.md
+++ b/skills/turbo-builder/SKILL.md
@@ -83,7 +83,7 @@ transforms:
       WHERE <conditions>
 ```
 
-### Step 6: Configure the Sink
+### Step 6: Configure the Sink(s)
 
 Ask where the data should go. Use the `/turbo-pipelines` skill for sink configuration:
 
@@ -94,6 +94,10 @@ Ask where the data should go. Use the `/turbo-pipelines` skill for sink configur
 | Kafka | `secret_name`, `topic` |
 | S3 | `bucket`, `region`, `prefix`, `format` |
 | Webhook | `url`, `format` |
+
+**If the user names more than one destination, generate ONE pipeline with multiple sinks — do not generate a separate pipeline per destination.** Each sink has a `from:` field that references the source (or a transform) by name, and sinks run independently. Use a fan-out pattern when different sinks want different views of the same source — add an SQL transform per view, then point each sink's `from:` at the appropriate transform. See `references/architecture-patterns.md` in `/turbo-pipelines` and `templates/multi-sink-pipeline.yaml` for examples.
+
+Only split into separate pipelines when sources are fundamentally different (e.g., different chains with independent lifecycles) or the user explicitly asks for separate pipelines.
 
 For sinks requiring `secret_name`, check if the secret exists:
 

--- a/skills/turbo-pipelines/SKILL.md
+++ b/skills/turbo-pipelines/SKILL.md
@@ -112,8 +112,13 @@ For full sink field specifications, read `references/sink-reference.md`.
 
 ### Pipeline Splitting
 
-**One pipeline when:** Shared source, shared intermediate transforms, atomic deployment.
-**Multiple pipelines when:** Different sources, different lifecycle needs, different resource sizes, different chains.
+**Default to one pipeline with multiple sinks** when the user wants the same source data sent to multiple destinations. A single Turbo pipeline supports multiple sinks natively — each sink has a `from:` field pointing at a source or transform by name, and sinks run independently (one failing does not block the others, and each can have its own `batch_size` / `batch_flush_interval`).
+
+**Do NOT split into separate pipelines just because there are multiple destinations.** Generating one pipeline per sink duplicates the source ingestion, wastes resources, and decouples deployments that should be atomic.
+
+**Split into multiple pipelines only when:** sources are fundamentally different (different chains with independent lifecycles), the destinations need different resource sizes, or the user explicitly asks for separate pipelines.
+
+See `references/architecture-patterns.md` for fan-out (one source → multiple sinks) and fan-in (UNION ALL) YAML examples, and `templates/multi-sink-pipeline.yaml` / `templates/fan-out-pipeline.yaml` / `templates/fan-in-pipeline.yaml` for ready-to-adapt configs.
 
 ---
 


### PR DESCRIPTION
## Summary

Reword the **Pipeline Splitting** section in `turbo-pipelines/SKILL.md` and **Step 6** in `turbo-builder/SKILL.md` so users (and LLMs) generating pipelines from these skills default to **one pipeline with multiple sinks** rather than one pipeline per destination.

The fan-out / fan-in / UNION ALL content (diagrams, full YAML, templates) already exists in `skills/turbo-pipelines/references/architecture-patterns.md` and `skills/turbo-pipelines/templates/`. The gap was the explicit anti-pattern rule — the existing wording was descriptive ("One pipeline when… / Multiple pipelines when…") rather than prescriptive, and `turbo-builder` Step 6 was titled "Configure the Sink" (singular), subtly reinforcing the wrong default.

## Why

This mirrors the system-prompt fix landing in [goldsky-io/goldsky#4749](https://github.com/goldsky-io/goldsky/pull/4749), where the chatbot was generating separate pipelines for each destination instead of one pipeline with multiple sinks. The chatbot loads these skills as its core knowledge, so users invoking the skills directly through Claude Code (outside the chatbot) hit the same anti-pattern unless the skills themselves carry the rule.

The chatbot PR will be slimmed down to drop the inlined topology examples once this lands — the skill becomes the single source of truth.

## Changes

- `skills/turbo-pipelines/SKILL.md` — strengthen "Pipeline Splitting" section with explicit "default to one pipeline, multiple sinks" rule, `from:` field guidance, sink independence note, and pointers to the existing architecture-patterns reference and templates.
- `skills/turbo-builder/SKILL.md` — rename Step 6 to "Configure the Sink(s)" and add a branch: if user names more than one destination, generate one pipeline with multiple sinks.

No new files. No duplicated YAML examples — they already live in `architecture-patterns.md` and the `templates/` directory.

## Test plan

- [ ] Read both edited sections end-to-end and confirm guidance reads imperatively without contradicting the existing pattern tables / templates.
- [ ] Spot-check that pointers to `references/architecture-patterns.md` and `templates/multi-sink-pipeline.yaml` resolve.