### PR TITLE
fix(turbo skills): stop steering to decoded_logs + harden multi-sink guidance

### DIFF
--- a/skills/datasets/SKILL.md
+++ b/skills/datasets/SKILL.md
@@ -97,9 +97,10 @@ sources:
 | `erc20_transfers`   | Fungible token transfers    | Token tracking, DeFi analytics       |
 | `erc721_transfers`  | NFT transfers               | NFT marketplaces, ownership tracking |
 | `erc1155_transfers` | Multi-token transfers       | Gaming, multi-token standards        |
-| `decoded_logs`      | ABI-decoded event logs      | Specific contract events             |
 
 > **Important:** Use `raw_transactions`, NOT `transactions`. Use `raw_logs`, NOT `logs` (though `logs` works as an alias on some chains).
+>
+> **There is no consumable `decoded_logs` source dataset.** For decoded contract events, source from `<chain>.raw_logs` and decode in a SQL transform via `_gs_log_decode(_gs_fetch_abi(<explorer-url>, <source>), topics, data)`. See `/turbo-transforms` for the full pattern.
 
 ### Solana
 
@@ -426,8 +427,8 @@ Dataset: `ethereum.erc721_transfers`
 
 ### "I want to monitor a specific smart contract"
 
-1. Dataset: `<chain>.logs` for raw events, or `<chain>.decoded_logs` for decoded events
-2. Filter by contract address in your transform
+1. Source: `<chain>.raw_logs`, filtered to the contract address in the source filter
+2. To decode events: add a SQL transform calling `_gs_log_decode(_gs_fetch_abi(<explorer-url>, <source>), topics, data) AS decoded`, then filter downstream by `WHERE decoded.event_signature = '<EventName>(<types>)'`. Never put topic0 hashes in the source filter.
 
 ### "I need multi-chain data"
 

--- a/skills/datasets/data/verified-datasets.json
+++ b/skills/datasets/data/verified-datasets.json
@@ -183,13 +183,6 @@
         "trace_id": "string",
         "block_timestamp": "integer (unix)"
       }
-    },
-    "decoded_logs": {
-      "description": "ABI-decoded event logs",
-      "useCase": "Specific contract events with human-readable data",
-      "chains": {
-        "ethereum": { "version": "1.0.0", "startAtSupport": true }
-      }
     }
   },
   "solana": {

--- a/skills/datasets/data/verified-datasets.json
+++ b/skills/datasets/data/verified-datasets.json
@@ -155,9 +155,10 @@
         "ethereum": { "version": "1.0.0", "startAtSupport": true }
       }
     },
-    "traces": {
+    "raw_traces": {
       "description": "Internal transactions and call traces",
       "useCase": "MEV analysis, contract interactions, deep transaction analysis",
+      "warning": "Use 'raw_traces' (canonical name per docs); 'traces' is an older alias still accepted on some chains.",
       "chains": {
         "ethereum": { "version": "1.0.0", "startAtSupport": true }
       },
@@ -182,6 +183,30 @@
         "status": "integer",
         "trace_id": "string",
         "block_timestamp": "integer (unix)"
+      }
+    },
+    "erc1155_transfers": {
+      "description": "ERC-1155 multi-token transfers (curated)",
+      "useCase": "Gaming, multi-token standards, NFT collections that mix fungible and non-fungible items",
+      "chains": {
+        "ethereum": { "version": "1.0.0", "startAtSupport": true },
+        "base": { "version": "1.0.0", "startAtSupport": true },
+        "matic": { "version": "1.0.0", "startAtSupport": true }
+      },
+      "schema": {
+        "id": "string",
+        "operator": "string",
+        "from_address": "string",
+        "to_address": "string",
+        "token_id": "decimal",
+        "value": "decimal",
+        "address": "string (token contract address)",
+        "block_number": "integer",
+        "block_timestamp": "integer (unix)",
+        "block_hash": "string",
+        "transaction_hash": "string",
+        "transaction_index": "integer",
+        "log_index": "integer"
       }
     }
   },

--- a/skills/turbo-builder/SKILL.md
+++ b/skills/turbo-builder/SKILL.md
@@ -39,8 +39,9 @@ If the user already described their goal, extract answers from their description
 Use the `/datasets` skill to find the right dataset.
 
 Key points:
-- Common datasets: `<chain>.decoded_logs`, `<chain>.raw_transactions`, `<chain>.erc20_transfers`, `<chain>.raw_traces`
-- For decoded contract events, use `<chain>.decoded_logs` with a filter on `address` and `topic0`
+- Common datasets: `<chain>.raw_logs`, `<chain>.raw_transactions`, `<chain>.erc20_transfers`, `<chain>.raw_traces`
+- For decoded contract events on EVM chains: source from `<chain>.raw_logs` with a filter on `address` ONLY, then add a SQL transform that calls `_gs_log_decode(_gs_fetch_abi(<explorer-url>, <source>), topics, data) AS decoded`, then filter downstream by `WHERE decoded.event_signature = '<EventName>(<types>)'`. Never put topic0 hashes in the source filter — see `/turbo-transforms` for the full pattern. There is no consumable `<chain>.decoded_logs` dataset; decoding always happens in a transform.
+- For pre-decoded common token events: `<chain>.erc20_transfers`, `<chain>.erc721_transfers`, `<chain>.erc1155_transfers` are available and don't need decoding transforms.
 - For Solana: use `solana.transactions`, `solana.token_transfers`, etc.
 
 Present the dataset choice to the user for confirmation.


### PR DESCRIPTION
## Summary

Two related fixes to the turbo skills:

- **`turbo-builder`: stop steering users to a nonexistent `<chain>.decoded_logs` dataset.** The skill told users to "use `<chain>.decoded_logs` with a filter on `address` and `topic0`" — but there is no consumable `decoded_logs` dataset in Goldsky. Decoding always happens in a transform via `_gs_log_decode + _gs_fetch_abi`. This wrong guidance is what pushed the chatbot to fabricate topic0 hashes for raw_logs source filters, observed in production conversations `conv_cmoskzxe4napr01xl94ix8to9` and `conv_cmotwa96mslbc01vve1tr3h8t` (Linear: APP-4483). Replaced with steering to the canonical raw_logs + `_gs_log_decode + _gs_fetch_abi` transform pattern, plus a note pointing to `/turbo-transforms` for the full pattern.
- **Multi-sink guidance hardening** (preexisting commit `8e34d6c`): prevents the chatbot from splitting a single fan-out request into multiple per-destination pipelines.

## How to test

1. Reload the chatbot's external skills (or wait for next deploy).
2. Ask the chatbot to "build a pipeline that decodes Transfer events from a contract on Base" — the bot should source from `base.raw_logs` filtered by `address` only, then add a SQL transform with `_gs_log_decode(_gs_fetch_abi(...), topics, data)`. It should NOT reference `base.decoded_logs` and should NOT put a topic0 hash in the source filter.
3. Ask the chatbot to "send the data to both PostgreSQL and ClickHouse" — should produce ONE pipeline with two sinks, not two pipelines.

### Expected result

- New chatbot conversations using EVM decoded events follow the canonical decoding pattern
- Companion PR in `goldsky-io/goldsky` provides the structural enforcement (provenance gates) that catches the fabrication path even if the steering misses

🤖 Generated with [Claude Code](https://claude.com/claude-code)