### PR TITLE
feat(turbo skills): document pubsub sink and throttle transform

### DIFF
--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: secrets
-description: "Use this skill when a user wants to store, manage, or work with Goldsky secrets — the named credential objects used by pipeline sinks. This includes: creating a new secret from a connection string or credentials, listing or inspecting existing secrets, updating or rotating credentials after a password change, and deleting secrets that are no longer needed. Trigger for any query where the user mentions 'goldsky secret', wants to securely store database credentials for a pipeline, or is working with sink authentication for PostgreSQL, Neon, Supabase, ClickHouse, Kafka, S3, Elasticsearch, DynamoDB, SQS, OpenSearch, or webhooks."
+description: "Use this skill when a user wants to store, manage, or work with Goldsky secrets — the named credential objects used by pipeline sinks. This includes: creating a new secret from a connection string or credentials, listing or inspecting existing secrets, updating or rotating credentials after a password change, and deleting secrets that are no longer needed. Trigger for any query where the user mentions 'goldsky secret', wants to securely store database credentials for a pipeline, or is working with sink authentication for PostgreSQL, Neon, Supabase, ClickHouse, Kafka, S3, Google Cloud Pub/Sub, Elasticsearch, DynamoDB, SQS, OpenSearch, or webhooks."
 ---
 
 # Goldsky Secrets Management
@@ -105,6 +105,7 @@ Run `goldsky secret list` to confirm creation.
 | ClickHouse    | `clickhouse.json`    | `clickHouse`    | Analytics database              |
 | Kafka         | `kafka.json`         | `kafka`         | Event streaming                 |
 | AWS S3        | `s3.json`            | `s3`            | Object storage                  |
+| Google Pub/Sub| —                    | `pubsub`        | GCP Pub/Sub topic (Turbo-only)  |
 | ElasticSearch | `elasticsearch.json` | `elasticSearch` | Search engine                   |
 | DynamoDB      | `dynamodb.json`      | `dynamodb`      | NoSQL database                  |
 | SQS           | `sqs.json`           | `sqs`           | Message queue                   |
@@ -152,6 +153,22 @@ access_key_id:secret_access_key
 ```
 
 Or with session token: `access_key_id:secret_access_key:session_token`
+
+**Google Cloud Pub/Sub** — JSON format (Turbo-only):
+
+```json
+{
+  "type": "pubsub",
+  "projectId": "goldsky-prod",
+  "credentialsJson": "{\"type\":\"service_account\",\"project_id\":\"goldsky-prod\",...}"
+}
+```
+
+The CLI prompts for the GCP project id and asks for the entire service-account JSON key as a single-line paste; it validates the paste is JSON with `type === "service_account"`.
+
+**IAM requirements:** the service account must have **`roles/pubsub.publisher`** AND **`roles/pubsub.viewer`**. The `viewer` role is required by the sink's topic-existence pre-check during initialization — a publish-only SA will fail sink init with a `PermissionDenied` error.
+
+The Pub/Sub topic itself must exist in the GCP project before deploying the pipeline; Goldsky does not auto-create topics.
 
 **Webhook:**
 

--- a/skills/turbo-builder/SKILL.md
+++ b/skills/turbo-builder/SKILL.md
@@ -93,6 +93,7 @@ Ask where the data should go. Use the `/turbo-pipelines` skill for sink configur
 | PostgreSQL | `secret_name`, `schema`, `table`, `primary_key` |
 | ClickHouse | `secret_name`, `table`, `order_by` |
 | Kafka | `secret_name`, `topic` |
+| Pub/Sub (Turbo-only) | `secret_name`, `topic` |
 | S3 | `bucket`, `region`, `prefix`, `format` |
 | Webhook | `url`, `format` |
 

--- a/skills/turbo-pipelines/SKILL.md
+++ b/skills/turbo-pipelines/SKILL.md
@@ -90,6 +90,7 @@ Start small and scale up — defensive sizing avoids wasted resources.
 | Real-time aggregates | `postgres_aggregate` | Balances, counters, running totals via triggers|
 | Analytics queries    | `clickhouse`         | Large-scale aggregations, time-series data    |
 | Event processing     | `kafka`              | Downstream consumers, event-driven systems    |
+| GCP messaging        | `pubsub`             | Google Cloud Pub/Sub topics (Turbo-only)       |
 | Serverless streaming | `s2_sink`            | S2.dev streams, alternative to Kafka          |
 | Notifications        | `webhook`            | Lambda functions, API callbacks, alerts        |
 | Data lake            | `s3_sink`            | Long-term archival, batch processing          |
@@ -191,12 +192,13 @@ No `start_at` or `version` fields. Optional: `filter`, `include_metadata`, `star
 
 ### Transform Configuration
 
-| Type            | Use Case                              |
-| --------------- | ------------------------------------- |
-| `sql`           | Filtering, projections, SQL functions |
-| `script`        | Custom TypeScript/WASM logic          |
-| `handler`       | Call external HTTP APIs to enrich     |
-| `dynamic_table` | Lookup tables backed by a database    |
+| Type            | Use Case                                       |
+| --------------- | ---------------------------------------------- |
+| `sql`           | Filtering, projections, SQL functions          |
+| `script`        | Custom TypeScript/WASM logic                   |
+| `handler`       | Call external HTTP APIs to enrich              |
+| `dynamic_table` | Lookup tables backed by a database             |
+| `throttle`      | Cap throughput to a fixed records-per-second   |
 
 #### SQL Transform
 
@@ -237,6 +239,30 @@ transforms:
 
 For TypeScript, handler, and dynamic table transforms, see `/turbo-transforms`.
 
+#### Throttle Transform
+
+Caps the throughput of a stream by buffering records into batches and emitting each batch on a fixed minimum interval. Throttle does **not** modify data — every input record passes through unchanged. Use it to stay under rate limits of downstream sinks or external APIs, smooth bursty sources, or pace records into HTTP handlers.
+
+```yaml
+transforms:
+  throttled:
+    type: throttle
+    from: my_source
+    max_batch_size: 100
+    min_batch_interval: 10s
+```
+
+| Field                | Required | Description                                                  |
+| -------------------- | -------- | ------------------------------------------------------------ |
+| `type`               | Yes      | `throttle`                                                   |
+| `from`               | Yes      | Source or transform to read from                             |
+| `max_batch_size`     | No       | Max records per batch                                        |
+| `min_batch_interval` | No       | Minimum time between batches (e.g. `10s`, `500ms`, `1m`)     |
+
+Effective max throughput ≈ `max_batch_size / min_batch_interval` records per second. Throttle limits the **maximum** rate, not the minimum — if upstream is slow, batches will be smaller and arrive less frequently.
+
+**Place throttle close to the bottleneck** (just before the rate-limited sink or handler) so upstream transforms still process at full speed.
+
 ### Sink Configuration
 
 Quick examples for common sinks. For full field specs of all sink types, read `references/sink-reference.md`.
@@ -266,6 +292,19 @@ sinks:
     primary_key: id
 ```
 
+#### Pub/Sub (Turbo-only)
+
+```yaml
+sinks:
+  output:
+    type: pubsub
+    from: my_transform
+    topic: my-topic
+    secret_name: MY_PUBSUB_SECRET
+```
+
+The secret holds a GCP project id and service-account JSON. Topic must already exist in GCP.
+
 #### Blackhole (Testing)
 
 ```yaml
@@ -294,6 +333,7 @@ To reset checkpoints: rename the source or pipeline. Warning: this reprocesses a
 | `minimal-erc20-blackhole.yaml` | Simplest pipeline, no credentials | Quick testing                |
 | `filtered-transfers-sql.yaml`  | Filter by contract address        | USDC, specific tokens        |
 | `postgres-output.yaml`         | Write to PostgreSQL               | Production data storage      |
+| `pubsub-output.yaml`           | Write to Google Cloud Pub/Sub     | GCP-based event consumers    |
 | `multi-chain-pipeline.yaml`    | Combine multiple chains           | Cross-chain analytics        |
 | `solana-transfers.yaml`        | Solana SPL tokens                 | Non-EVM chains               |
 | `multi-sink-pipeline.yaml`     | Multiple outputs                  | Archive + alerts + streaming |

--- a/skills/turbo-pipelines/references/sink-reference.md
+++ b/skills/turbo-pipelines/references/sink-reference.md
@@ -10,10 +10,11 @@ Complete field reference for all Turbo pipeline sink types.
 4. [PostgreSQL Aggregate](#postgresql-aggregate)
 5. [ClickHouse](#clickhouse)
 6. [Kafka](#kafka)
-7. [Webhook](#webhook)
-8. [S3](#s3)
-9. [S2](#s2)
-10. [Multi-Sink Considerations](#multi-sink-considerations)
+7. [Pub/Sub](#pubsub)
+8. [Webhook](#webhook)
+9. [S3](#s3)
+10. [S2](#s2)
+11. [Multi-Sink Considerations](#multi-sink-considerations)
 
 ---
 
@@ -121,6 +122,37 @@ sinks:
     data_format: avro          # or: json
     schema_registry_url: http://schema-registry:8081  # required for avro
 ```
+
+---
+
+## Pub/Sub
+
+Publish records to a [Google Cloud Pub/Sub](https://cloud.google.com/pubsub) topic. **Turbo-only sink** — not available on stream pipelines.
+
+```yaml
+sinks:
+  pubsub_output:
+    type: pubsub
+    from: my_transform
+    topic: my-topic
+    secret_name: MY_PUBSUB_SECRET
+    # Optional batching:
+    # batch_size: 1000
+    # batch_flush_interval: 1s
+```
+
+| Field                  | Required | Description                                                              |
+| ---------------------- | -------- | ------------------------------------------------------------------------ |
+| `type`                 | Yes      | `pubsub`                                                                 |
+| `from`                 | Yes      | Source or transform to read from                                         |
+| `topic`                | Yes      | Pub/Sub topic name (must already exist in the GCP project)               |
+| `secret_name`          | Yes      | Secret holding the GCP project id and service-account JSON               |
+| `batch_size`           | No       | Records per batch                                                        |
+| `batch_flush_interval` | No       | Max time between flushes (e.g. `1s`, `500ms`)                            |
+
+**Secret format** (`type: pubsub`): a GCP project id and a raw service-account JSON key. See `/secrets` for the create flow. The IAM role on the service account must include **`roles/pubsub.publisher`** AND **`roles/pubsub.viewer`** (the `viewer` role is needed by the sink's topic-existence pre-check during initialization — a publish-only SA will fail sink init with `PermissionDenied`).
+
+The topic must exist in GCP before deploying the pipeline — Goldsky does not auto-create topics.
 
 ---
 

--- a/skills/turbo-pipelines/references/validation-checklist.md
+++ b/skills/turbo-pipelines/references/validation-checklist.md
@@ -27,7 +27,7 @@ For each source entry:
 
 For each transform entry:
 
-- [ ] `type` is one of: `sql`, `script`, `handler`, `dynamic_table`
+- [ ] `type` is one of: `sql`, `script`, `handler`, `dynamic_table`, `throttle`
 - [ ] For `type: sql`:
   - [ ] `primary_key` is specified
   - [ ] `sql` field contains a SELECT statement
@@ -41,18 +41,24 @@ For each transform entry:
   - [ ] If `backend_type: Postgres`, `secret_name` is specified
 - [ ] For `type: handler`:
   - [ ] `primary_key`, `from`, and `url` are present
+- [ ] For `type: throttle`:
+  - [ ] `from` references an existing source or earlier transform
+  - [ ] If specified, `max_batch_size` is a positive integer
+  - [ ] If specified, `min_batch_interval` is a duration string (e.g. `10s`, `500ms`, `1m`)
+  - [ ] `primary_key` is NOT required (throttle passes records through unchanged)
 
 ## Sinks
 
 For each sink entry:
 
-- [ ] `type` is one of: `postgres`, `postgres_aggregate`, `clickhouse`, `kafka`, `webhook`, `s3_sink`, `s2_sink`, `blackhole`
+- [ ] `type` is one of: `postgres`, `postgres_aggregate`, `clickhouse`, `kafka`, `pubsub`, `webhook`, `s3_sink`, `s2_sink`, `blackhole`
 - [ ] `from` references a valid source or transform key name
 - [ ] Required fields by type:
   - `postgres`: `schema`, `table`, `secret_name`, `primary_key`
   - `postgres_aggregate`: `schema`, `landing_table`, `agg_table`, `primary_key`, `secret_name`, `group_by`, `aggregate`
   - `clickhouse`: `table`, `secret_name`, `primary_key`
   - `kafka`: `topic`
+  - `pubsub`: `topic`, `secret_name` (Turbo-only sink)
   - `s3_sink`: `endpoint`, `bucket`, `secret_name`
   - `s2_sink`: `access_token`, `basin`, `stream`
   - `webhook`: `url` (no `secret_name`)

--- a/skills/turbo-pipelines/templates/pubsub-output.yaml
+++ b/skills/turbo-pipelines/templates/pubsub-output.yaml
@@ -1,0 +1,39 @@
+# Pub/Sub Output Pipeline (Turbo-only)
+# Streams ERC-20 transfers from Base into a Google Cloud Pub/Sub topic.
+#
+# Prerequisites:
+#   1. The Pub/Sub topic must already exist in your GCP project
+#      (Goldsky does not auto-create topics).
+#   2. Create a GCP service account and grant it BOTH:
+#        - roles/pubsub.publisher  (to publish messages)
+#        - roles/pubsub.viewer     (required by the sink's topic-existence pre-check at init)
+#      A publish-only SA will fail sink init with PermissionDenied.
+#   3. Create the secret with the GCP project id and service-account JSON:
+#        goldsky secret create --name PUBSUB_SANDBOX
+#        # (the CLI prompts for project id, then for the SA JSON as a single-line paste)
+#
+# Usage:
+#   1. Update `name`, `topic`, and `secret_name` below.
+#   2. Run: goldsky turbo apply pubsub-output.yaml
+
+name: base-erc20-transfers-pubsub
+resource_size: s
+
+sources:
+  transfers:
+    type: dataset
+    dataset_name: base.erc20_transfers
+    version: 1.2.0
+    start_at: latest
+
+transforms: {}
+
+sinks:
+  pubsub_output:
+    type: pubsub
+    from: transfers
+    topic: erc20-transfers
+    secret_name: PUBSUB_SANDBOX
+    # Optional batching:
+    # batch_size: 1000
+    # batch_flush_interval: 1s

--- a/skills/turbo-transforms/SKILL.md
+++ b/skills/turbo-transforms/SKILL.md
@@ -35,11 +35,11 @@ transforms:
 
 ### Required Fields
 
-| Field         | Required | Description                                      |
-| ------------- | -------- | ------------------------------------------------ |
-| `type`        | Yes      | `sql`, `script`, `handler`, or `dynamic_table`   |
-| `primary_key` | Yes      | Column used for uniqueness and ordering           |
-| `sql`         | Yes      | SQL query (for `sql` type transforms)            |
+| Field         | Required | Description                                                  |
+| ------------- | -------- | ------------------------------------------------------------ |
+| `type`        | Yes      | `sql`, `script`, `handler`, `dynamic_table`, or `throttle`   |
+| `primary_key` | Yes\*    | Column used for uniqueness and ordering (\*not for `throttle`) |
+| `sql`         | Yes      | SQL query (for `sql` type transforms)                        |
 
 ### Referencing Data
 
@@ -289,6 +289,41 @@ Updatable lookup tables for allowlists, blocklists, and join-style enrichment �
 See `references/dynamic-tables.md` for full config, backend options, REST API updates, and wallet-tracking example.
 
 ---
+
+## Throttle Transform (Flow Control)
+
+Caps the throughput of a stream by buffering records into batches and emitting each batch on a fixed minimum interval. Throttle does **not** modify data — every input record passes through unchanged. Use it to:
+
+- Stay under rate limits of downstream sinks or external APIs
+- Smooth bursty sources into a steady, predictable rate
+- Pace records into an HTTP `handler` so the receiving service is not overwhelmed
+- Slow down processing during development or testing
+
+```yaml
+transforms:
+  throttled:
+    type: throttle
+    from: my_source       # source or transform
+    max_batch_size: 100
+    min_batch_interval: 10s
+```
+
+| Field                | Required | Description                                              |
+| -------------------- | -------- | -------------------------------------------------------- |
+| `type`               | Yes      | `throttle`                                               |
+| `from`               | Yes      | Source or transform to read from                         |
+| `max_batch_size`     | No       | Max records per batch                                    |
+| `min_batch_interval` | No       | Minimum time between batches (e.g. `10s`, `500ms`, `1m`) |
+
+A batch is flushed downstream when **both** `max_batch_size` records have accumulated **and** `min_batch_interval` has elapsed since the previous batch. Effective max throughput ≈ `max_batch_size / min_batch_interval` records per second.
+
+**Best practices:**
+
+- Place throttle close to the bottleneck (just before the rate-limited sink/handler) so upstream transforms still process at full speed.
+- Tune `max_batch_size` to match the downstream sink's preferred batch size.
+- Throttle is a `transform` — chain other transforms downstream from it the same way you would any other transform (e.g. `from: throttled` in a sink).
+- Throttle does not have a `primary_key` field (records pass through unchanged).
+- Remove throttle in production where possible; it caps throughput by design.
 
 ## Solana Transform Patterns
 

--- a/skills/turbo-transforms/templates/throttled-webhook.yaml
+++ b/skills/turbo-transforms/templates/throttled-webhook.yaml
@@ -1,0 +1,36 @@
+# Throttled Webhook Pipeline
+# Caps a high-volume stream at ~10 records/second before sending to a webhook
+# so the receiving service is not overwhelmed and per-second rate limits
+# are respected.
+#
+# Effective rate ≈ max_batch_size / min_batch_interval = 100 / 10s = 10 rps
+#
+# Place the throttle JUST BEFORE the rate-limited sink so upstream transforms
+# still process at full speed.
+#
+# Usage:
+#   1. Replace the webhook URL.
+#   2. Run: goldsky turbo apply throttled-webhook.yaml
+
+name: base-erc20-transfers-throttled-webhook
+resource_size: s
+
+sources:
+  transfers:
+    type: dataset
+    dataset_name: base.erc20_transfers
+    version: 1.2.0
+    start_at: latest
+
+transforms:
+  throttled:
+    type: throttle
+    from: transfers
+    max_batch_size: 100
+    min_batch_interval: 10s
+
+sinks:
+  webhook_output:
+    type: webhook
+    from: throttled
+    url: https://api.example.com/transfers


### PR DESCRIPTION
## Summary

Teach the Goldsk(ai) chatbot (and any other agent that loads these skills) about two new Turbo pipeline primitives shipping in the goldsky monorepo and streamling-cloud:

- **`pubsub` sink** (Turbo-only) — Google Cloud Pub/Sub destination, plus the matching `pubsub` secret type.
- **`throttle` transform** — caps stream throughput by buffering records into batches and emitting on a fixed minimum interval; passes records through unchanged.

The chatbot's split-brain architecture puts new sink/transform reference material in this repo (loaded on demand via `loadSkill`, 1hr cache), so no api-server deploy is needed — changes propagate automatically once merged.

### Pub/Sub sink

- `skills/turbo-pipelines/SKILL.md` — added to Sink Selection table, Sink Configuration quick example, and Starter Templates table.
- `skills/turbo-pipelines/references/sink-reference.md` — new Pub/Sub section with full field table, IAM requirements (`roles/pubsub.publisher` + `roles/pubsub.viewer`), and the topic-must-already-exist caveat.
- `skills/turbo-pipelines/references/validation-checklist.md` — added to sink types list with required fields.
- `skills/secrets/SKILL.md` — added to secret types table, JSON example, IAM notes; updated front-matter `description` so the skill triggers on Pub/Sub queries.
- `skills/turbo-builder/SKILL.md` — added Pub/Sub row to sink config table.
- `skills/turbo-pipelines/templates/pubsub-output.yaml` — new starter template with prerequisites checklist.

### Throttle transform

- `skills/turbo-pipelines/SKILL.md` — added to Transform Configuration table with a dedicated section covering the rate formula (`max_batch_size / min_batch_interval`), placement guidance, and the fact that throttle does not modify data.
- `skills/turbo-transforms/SKILL.md` — full reference section with use cases, field table, semantics, best practices, and a note that `primary_key` is not required (records pass through unchanged).
- `skills/turbo-pipelines/references/validation-checklist.md` — added to transform types list with field rules.
- `skills/turbo-transforms/templates/throttled-webhook.yaml` — template demonstrating throttle placed just before a rate-limited webhook (~10 rps cap).

### Companion PRs

- goldsky webapp pubsub: goldsky-io/goldsky#4776
- goldsky webapp throttle: goldsky-io/goldsky#4780
- streamling-cloud pubsub: goldsky-io/streamling-cloud#153

## How to test

Manual review of the rendered SKILL.md files for accuracy:

1. **Pub/Sub sink reference matches the schema** — `type: pubsub`, `from`, `topic`, `secret_name` required; `batch_size` / `batch_flush_interval` optional. Topic name and IAM constraints match the streamling-cloud + plugin contract.
2. **Throttle reference matches the doc** — fields match `ThrottleTransformTypeBox` (`from` required, `max_batch_size` and `min_batch_interval` optional), and the rate formula matches https://docs.goldsky.com/turbo-pipelines/transforms/throttle.
3. **Templates parse as valid YAML** — `pubsub-output.yaml` and `throttled-webhook.yaml` are syntactically valid and self-explanatory.
4. **Chatbot picks up the changes** — once merged, restart the api-server (or wait up to 1hr for the skill cache to refresh), then ask the chatbot "build me a pipeline that publishes Base ERC-20 transfers to Google Cloud Pub/Sub" or "throttle this pipeline to 10 records per second" and verify it generates correct YAML using the new types.

### Expected result

The agent can answer questions about the `pubsub` sink, the `pubsub` secret type, and the `throttle` transform; can generate valid pipeline YAML using them; and surfaces the IAM / topic-existence caveats for Pub/Sub.

## Tasks

- [ ] Merge — changes propagate automatically (1hr skill cache TTL)

Made with [Cursor](https://cursor.com)