### PR TITLE
docs(readme): sync skill catalog with current skill set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # Goldsky Agent
 
 [![Install with npx](https://img.shields.io/badge/install-npx%20skills%20add-blue)](https://github.com/goldsky-io/goldsky-agent#installation)
-[![Skills](https://img.shields.io/badge/skills-10-green)](#skills)
+[![Skills](https://img.shields.io/badge/skills-16-green)](#skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-AI-powered tools for streaming real-time blockchain data. Build, deploy, and debug Turbo pipelines that index onchain events from 130+ chains into PostgreSQL, ClickHouse, Kafka, and more.
+AI-powered tools for the full Goldsky product surface. Build, deploy, and debug Turbo pipelines, Mirror pipelines, Subgraphs, Compose apps, and Edge RPC — from natural-language prompts.
 
 ## Quick Start
 
-| I want to...                          | Use                  |
-| ------------------------------------- | -------------------- |
-| Build a new pipeline                  | `/turbo-builder`     |
-| Fix a broken pipeline                 | `/turbo-doctor`      |
-| Find the right dataset name           | `/datasets`          |
-| Look up YAML syntax                   | `/turbo-pipelines`   |
-| Check error patterns or CLI commands  | `/turbo-operations`  |
+| I want to...                                          | Use                  |
+| ----------------------------------------------------- | -------------------- |
+| Build a new Turbo pipeline                            | `/turbo-builder`     |
+| Fix a broken Turbo pipeline                           | `/turbo-doctor`      |
+| Fix a broken Mirror pipeline                          | `/mirror-doctor`     |
+| Fix a broken Compose app                              | `/compose-doctor`    |
+| Find the right dataset name                           | `/datasets`          |
+| Look up Turbo YAML syntax                             | `/turbo-pipelines`   |
+| Look up Compose manifest, CLI flags, or TaskContext   | `/compose-reference` |
+| Set up the CLI and log in                             | `/auth-setup`        |
 
 Just describe what you need in natural language — the right skill is selected automatically.
 
@@ -83,16 +86,21 @@ cp -r goldsky-agent/skills/* .cursor/skills/    # Cursor
 goldsky-agent/
 ├── skills/              # All skills (auto-triggered by description matching)
 │   ├── turbo-builder/         # Step-by-step pipeline creation wizard
-│   ├── turbo-doctor/          # Diagnose and fix pipeline issues
+│   ├── turbo-doctor/          # Diagnose and fix Turbo pipeline issues
 │   ├── turbo-pipelines/       # YAML config + architecture reference
 │   ├── turbo-transforms/      # SQL, TypeScript, dynamic tables
 │   ├── turbo-operations/      # Lifecycle commands, monitoring, errors
+│   ├── mirror/                # Mirror pipeline deploy, operate, sources/sinks reference
+│   ├── mirror-doctor/         # Diagnose and fix Mirror pipelines
+│   ├── subgraphs/             # Subgraph deploy, GraphQL endpoints, tags
+│   ├── compose/               # Compose app scaffolding, triggers, wallets
+│   ├── compose-doctor/        # Diagnose and fix Compose apps
+│   ├── compose-reference/     # compose.yaml fields, CLI flags, TaskContext API
+│   ├── edge/                  # Managed RPC capabilities, error codes, pricing
 │   ├── datasets/              # Chain prefixes, dataset types
 │   ├── secrets/               # Credential management
 │   ├── auth-setup/            # CLI installation, login
-│   ├── cli-reference/         # All valid CLI commands + flags (auto-generated)
-│   └── mirror/                # Mirror pipeline deploy, operate, sources/sinks reference
-│   └── subgraphs/             # Subgraph deploy, GraphQL endpoints, tags reference
+│   └── cli-reference/         # All valid CLI commands + flags (auto-generated)
 ├── scripts/             # Maintenance scripts
 │   └── generate-cli-reference.js  # Regenerates cli-reference skill from installed CLI
 ├── hooks/               # Pre/post deploy automation
@@ -116,30 +124,65 @@ Generated pipeline.yaml + deployment
 
 ## Skills
 
-### Interactive Skills
+Skills are grouped by product. Each group has interactive workflow skills (guided, multi-step) and/or reference skills (lookup-oriented).
 
-These guide you through processes, help make decisions, or walk you through multi-step tasks:
+### Turbo pipelines
+
+Streaming pipelines that index onchain data from 130+ chains into PostgreSQL, ClickHouse, Kafka, S3, and more.
 
 | Skill | When to use | What it does |
 | ----- | ----------- | ------------ |
 | `turbo-builder` | "I want to build a pipeline for X" | Guides you chain → dataset → transforms → sink → validate → deploy |
 | `turbo-doctor` | "My pipeline is broken / not getting data / output looks wrong" | Diagnoses the problem step-by-step and offers to run fixes |
-| `auth-setup` | "How do I install the CLI / log in?" | Walks through CLI installation and authentication setup |
-| `secrets` | "How do I create credentials for PostgreSQL / ClickHouse?" | Guides credential creation and secret management |
-
-### Reference Skills
-
-Look up syntax, commands, and information without a guided workflow:
-
-| Skill | When to use | What's inside |
-| ----- | ----------- | ------------- |
 | `turbo-pipelines` | "What's the YAML syntax for X? Should I use dataset or Kafka?" | Config field reference + architecture decisions (source types, flow patterns, sizing) |
 | `turbo-transforms` | "How do I decode EVM logs / write a SQL transform?" | SQL, TypeScript/WASM, dynamic tables, HTTP handlers |
 | `turbo-operations` | "How do I pause / restart / delete? What does this error mean?" | Lifecycle commands, pipeline states, CLI monitoring, error patterns |
-| `datasets` | "What's the dataset name for Polygon NFTs?" | Chain prefixes, dataset types, naming conventions |
+
+### Mirror pipelines
+
+Goldsky's original streaming pipeline product — the only one that supports subgraph entity sources.
+
+| Skill | When to use | What it does |
+| ----- | ----------- | ------------ |
+| `mirror` | "How do I sync my subgraph to PostgreSQL? Mirror vs Turbo?" | Sources, sinks, lifecycle commands, Mirror vs Turbo guidance |
+| `mirror-doctor` | "My Mirror pipeline is failing / stuck / terminated" | Runs status and log commands, identifies root cause, applies fixes |
+
+### Subgraphs
+
+Hosted GraphQL APIs over indexed onchain data.
+
+| Skill | When to use | What's inside |
+| ----- | ----------- | ------------- |
+| `subgraphs` | "Deploy a subgraph / migrate from The Graph / manage GraphQL endpoints" | Deploy paths, GraphQL endpoints, tags, webhooks, cross-chain patterns |
+
+### Compose
+
+Offchain-to-onchain TypeScript framework for oracles, keepers, circuit breakers, and cross-chain automation.
+
+| Skill | When to use | What it does |
+| ----- | ----------- | ------------ |
+| `compose` | "Build a price oracle / keeper / cross-chain bot in TypeScript" | Walks through scaffolding, task triggers (cron, HTTP, onchain), wallets, gas sponsorship |
+| `compose-doctor` | "My Compose app is in error state / crashlooping" | Runs `status`, `logs`, `secret list`, `wallet list` and diagnoses |
+| `compose-reference` | "What fields does `compose.yaml` accept? What's the `TaskContext` API?" | Manifest fields, every `goldsky compose` flag, TaskContext / wallet / Collection APIs |
+
+### Edge (managed RPC)
+
+Globally distributed, low-latency JSON-RPC for EVM chains, built on eRPC.
+
+| Skill | When to use | What's inside |
+| ----- | ----------- | ------------- |
+| `edge` | "RPC rate limits, hedged requests, flashblocks, x402, error code -32005" | Capabilities, supported chains, pricing, dashboard, error code reference |
+
+### Cross-cutting
+
+Used across multiple products.
+
+| Skill | When to use | What it does |
+| ----- | ----------- | ------------ |
+| `auth-setup` | "Install the CLI / log in / switch projects / fix unauthorized errors" | Walks through CLI installation, login, and project switching |
+| `secrets` | "Create credentials for PostgreSQL / ClickHouse / Kafka / webhook sinks" | Guides credential creation and secret management |
+| `datasets` | "What's the dataset name for Polygon NFTs? What prefix does Solana use?" | Chain prefixes, dataset types, naming conventions |
 | `cli-reference` | Consulted automatically before any `goldsky` command | All valid subcommands, arguments, and flags — generated from the installed CLI |
-| `mirror` | "How do I sync my subgraph to PostgreSQL / create a Mirror pipeline?" | Sources, sinks, lifecycle commands, Mirror vs Turbo guidance |
-| `subgraphs` | "How do I deploy a subgraph / migrate from The Graph?" | Deploy paths, GraphQL endpoints, tags, webhooks, cross-chain patterns |
 
 ## Pre-Deploy Hooks
 
@@ -155,14 +198,14 @@ The plugin runs hooks automatically on `goldsky turbo apply` commands:
 
 ## Coverage
 
-These tools cover the full Turbo pipeline surface:
+The skills cover the full Goldsky product surface:
 
-- **Sources** — 130+ chains (EVM, Solana, Bitcoin, Stellar, Sui, NEAR, Starknet), source filtering, bounded ranges
-- **Transforms** — SQL, TypeScript/WASM, dynamic tables, HTTP handlers
-- **Sinks** — PostgreSQL, ClickHouse, Kafka, S3, Webhook, S2
-- **Modes** — Streaming (continuous) and Job (batch with `end_block`)
-- **Lifecycle** — Deploy, pause, resume, restart, delete
-- **Monitoring** — Live inspect (`-p` flag), log analysis, error matching
+- **Turbo pipelines** — 130+ chain sources (EVM, Solana, Bitcoin, Stellar, Sui, NEAR, Starknet); SQL / TypeScript / dynamic table transforms; PostgreSQL, ClickHouse, Kafka, S3, Webhook, S2, SQS, MySQL, Pub/Sub sinks; streaming and job modes; full lifecycle and monitoring
+- **Mirror pipelines** — Subgraph and direct-indexing sources, sinks, lifecycle, plus interactive diagnosis
+- **Subgraphs** — Deploy, tags, webhooks, cross-chain, migration from The Graph
+- **Compose** — `compose.yaml` manifest, cron / HTTP / onchain triggers, smart wallets, gas sponsorship, `TaskContext` API, codegen, pricing
+- **Edge RPC** — Capabilities, supported chains, hedged requests, flashblocks, x402, error code lookups
+- **Cross-cutting** — Authentication, secrets, dataset naming, full CLI reference
 
 ## MCP Server
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,26 +1,36 @@
 # Goldsky Agent Skills
 
-AI-powered tools for building, deploying, and debugging Turbo pipelines that stream real-time blockchain data from 130+ chains.
+AI-powered tools for building, deploying, and debugging across the full Goldsky product surface — Turbo pipelines, Mirror pipelines, Subgraphs, Compose, and Edge RPC.
 
 ## Available Skills
 
-### Pipeline Building
+### Turbo pipelines
 - **turbo-builder** - Interactive wizard for creating pipelines step-by-step
+- **turbo-doctor** - Interactive troubleshooting workflows
 - **turbo-pipelines** - YAML configuration and architecture reference (sources, transforms, sinks, design patterns)
 - **turbo-transforms** - SQL, TypeScript, and dynamic table transforms
-
-### Pipeline Operations
 - **turbo-operations** - Lifecycle commands, monitoring, and error patterns
-- **turbo-doctor** - Interactive troubleshooting workflows
 
-### Data & Configuration
-- **datasets** - Chain prefixes, dataset types, 130+ chains
-- **secrets** - Credential management for sinks (PostgreSQL, ClickHouse, Kafka)
-- **auth-setup** - CLI installation and authentication
+### Mirror pipelines
+- **mirror** - Sources, sinks, lifecycle commands, and guidance on Mirror vs Turbo
+- **mirror-doctor** - Diagnose and fix broken Mirror pipelines interactively
 
-### Other Products
-- **mirror** - Mirror pipeline sources, sinks, lifecycle commands, and guidance on Mirror vs Turbo
+### Subgraphs
 - **subgraphs** - Deploy subgraphs, manage GraphQL endpoints and tags, migrate from The Graph
+
+### Compose
+- **compose** - Build offchain-to-onchain TypeScript tasks (oracles, keepers, automation)
+- **compose-doctor** - Diagnose and fix broken Compose apps interactively
+- **compose-reference** - `compose.yaml` fields, every `goldsky compose` flag, `TaskContext` / wallet / Collection APIs
+
+### Edge (managed RPC)
+- **edge** - Managed RPC endpoints, capabilities, supported chains, error code lookups
+
+### Cross-cutting
+- **datasets** - Chain prefixes, dataset types, 130+ chains
+- **secrets** - Credential management for sinks (PostgreSQL, ClickHouse, Kafka, etc.)
+- **auth-setup** - CLI installation and authentication
+- **cli-reference** - All valid `goldsky` subcommands, arguments, and flags (auto-generated)
 
 ## Quick Start
 
@@ -40,11 +50,18 @@ npx skills add goldsky-io/goldsky-agent
 **"My pipeline is stuck in error state"**
 → Uses: turbo-doctor, turbo-operations
 
+**"My Compose app is crashlooping"**
+→ Uses: compose-doctor, compose-reference
+
+**"Sync my subgraph entities into PostgreSQL"**
+→ Uses: mirror, secrets
+
 **"What dataset for Polygon NFTs?"**
 → Uses: datasets
 
 ## Documentation
 
 - [Goldsky Docs](https://docs.goldsky.com)
+- [AI Skills page](https://docs.goldsky.com/ai-skills)
 - [GitHub Repository](https://github.com/goldsky-io/goldsky-agent)
 - [Installation Guide](https://github.com/goldsky-io/goldsky-agent#installation)


### PR DESCRIPTION
## Summary

- Reorganizes README + SKILLS.md by product (Turbo, Mirror, Subgraphs, Compose, Edge, cross-cutting) instead of the old interactive/reference split
- Adds the skills that exist in \`skills/\` but were missing from the catalog: \`mirror-doctor\`, \`compose\`, \`compose-doctor\`, \`compose-reference\`, \`edge\`
- Updates the repository structure tree, coverage section, Quick Start table, and bumps the badge from 10 → 16
- Companion to https://github.com/goldsky-io/docs/pull/396

## Test plan

- [ ] Skim the rendered README on GitHub
- [ ] Confirm every directory under \`skills/\` (excluding empty \`local-api-logs/\`) is referenced in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)