### PR TITLE
feat(turbo skills): document MySQL and SQS sinks

### DIFF
--- a/skills/turbo-builder/SKILL.md
+++ b/skills/turbo-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: turbo-builder
-description: "Build and deploy new Goldsky Turbo pipelines from scratch. Triggers on: 'build a pipeline', 'index X on Y chain', 'set up a pipeline', 'track transfers to postgres', or any request describing data to move from a chain/contract to a destination (postgres, clickhouse, kafka, s3, webhook). Covers the full workflow: requirements → dataset selection → YAML generation → validation → deploy. Not for debugging (use /turbo-doctor) or syntax lookups (use /turbo-pipelines)."
+description: "Build and deploy new Goldsky Turbo pipelines from scratch. Triggers on: 'build a pipeline', 'index X on Y chain', 'set up a pipeline', 'track transfers to postgres', or any request describing data to move from a chain/contract to a destination (postgres, mysql, clickhouse, kafka, pubsub, s3, sqs, webhook). Covers the full workflow: requirements → dataset selection → YAML generation → validation → deploy. Not for debugging (use /turbo-doctor) or syntax lookups (use /turbo-pipelines)."
 ---
 
 # Pipeline Builder
@@ -91,9 +91,11 @@ Ask where the data should go. Use the `/turbo-pipelines` skill for sink configur
 | Sink | Key config |
 |------|-----------|
 | PostgreSQL | `secret_name`, `schema`, `table`, `primary_key` |
+| MySQL | `secret_name`, `schema`, `table`, `primary_key` (optional, enables upsert) |
 | ClickHouse | `secret_name`, `table`, `order_by` |
 | Kafka | `secret_name`, `topic` |
 | Pub/Sub (Turbo-only) | `secret_name`, `topic` |
+| SQS | `secret_name`, `queue_url` |
 | S3 | `bucket`, `region`, `prefix`, `format` |
 | Webhook | `url`, `format` |
 

--- a/skills/turbo-pipelines/SKILL.md
+++ b/skills/turbo-pipelines/SKILL.md
@@ -84,17 +84,19 @@ Start small and scale up — defensive sizing avoids wasted resources.
 
 ### Sink Selection
 
-| Destination          | Sink Type            | Best For                                      |
-| -------------------- | -------------------- | --------------------------------------------- |
-| Application DB       | `postgres`           | Row-level lookups, joins, application serving |
+| Destination          | Sink Type            | Best For                                       |
+| -------------------- | -------------------- | ---------------------------------------------- |
+| Application DB       | `postgres`           | Row-level lookups, joins, application serving  |
 | Real-time aggregates | `postgres_aggregate` | Balances, counters, running totals via triggers|
-| Analytics queries    | `clickhouse`         | Large-scale aggregations, time-series data    |
-| Event processing     | `kafka`              | Downstream consumers, event-driven systems    |
+| MySQL-compatible DB  | `mysql`              | Existing MySQL stacks, upserts on primary key  |
+| Analytics queries    | `clickhouse`         | Large-scale aggregations, time-series data     |
+| Event processing     | `kafka`              | Downstream consumers, event-driven systems     |
+| AWS messaging        | `sqs_sink`           | Decoupled AWS consumers (standard queues only) |
 | GCP messaging        | `pubsub`             | Google Cloud Pub/Sub topics (Turbo-only)       |
-| Serverless streaming | `s2_sink`            | S2.dev streams, alternative to Kafka          |
+| Serverless streaming | `s2_sink`            | S2.dev streams, alternative to Kafka           |
 | Notifications        | `webhook`            | Lambda functions, API callbacks, alerts        |
-| Data lake            | `s3_sink`            | Long-term archival, batch processing          |
-| Testing              | `blackhole`          | Validate pipeline without writing data        |
+| Data lake            | `s3_sink`            | Long-term archival, batch processing           |
+| Testing              | `blackhole`          | Validate pipeline without writing data         |
 
 For full sink field specifications, read `references/sink-reference.md`.
 

--- a/skills/turbo-pipelines/evals/trigger-eval.json
+++ b/skills/turbo-pipelines/evals/trigger-eval.json
@@ -15,6 +15,8 @@
   {"query": "help me think through the architecture for a multi-chain NFT tracker that feeds both a postgres API database and a clickhouse analytics warehouse", "should_trigger": true},
   {"query": "what's the best sink for real-time aggregate balances that need to update incrementally?", "should_trigger": true},
   {"query": "what are all the available sink types i can write to?", "should_trigger": true},
+  {"query": "how do i set up a mysql sink? do i need a primary_key for upserts?", "should_trigger": true},
+  {"query": "what fields does the sqs_sink take and how do i point it at a queue?", "should_trigger": true},
   {"query": "walk me through building and deploying a complete pipeline for base erc20 transfers", "should_trigger": false},
   {"query": "how do i write a SQL transform to decode EVM event logs?", "should_trigger": false},
   {"query": "my pipeline is throwing schema mismatch errors, help me debug and fix it", "should_trigger": false},

--- a/skills/turbo-pipelines/references/sink-reference.md
+++ b/skills/turbo-pipelines/references/sink-reference.md
@@ -8,13 +8,15 @@ Complete field reference for all Turbo pipeline sink types.
 2. [Blackhole (Testing)](#blackhole-testing)
 3. [PostgreSQL](#postgresql)
 4. [PostgreSQL Aggregate](#postgresql-aggregate)
-5. [ClickHouse](#clickhouse)
-6. [Kafka](#kafka)
-7. [Pub/Sub](#pubsub)
-8. [Webhook](#webhook)
-9. [S3](#s3)
-10. [S2](#s2)
-11. [Multi-Sink Considerations](#multi-sink-considerations)
+5. [MySQL](#mysql)
+6. [ClickHouse](#clickhouse)
+7. [Kafka](#kafka)
+8. [Pub/Sub](#pubsub)
+9. [Webhook](#webhook)
+10. [S3](#s3)
+11. [SQS](#sqs)
+12. [S2](#s2)
+13. [Multi-Sink Considerations](#multi-sink-considerations)
 
 ---
 
@@ -86,6 +88,41 @@ sinks:
 ```
 
 Supported aggregation functions: `sum`, `count`, `avg`, `min`, `max`
+
+---
+
+## MySQL
+
+```yaml
+sinks:
+  mysql_output:
+    type: mysql
+    from: my_transform
+    schema: my_database       # MySQL treats schema and database as synonyms
+    table: my_table
+    secret_name: MY_MYSQL_SECRET
+    primary_key: id           # Optional — enables upsert (ON DUPLICATE KEY UPDATE)
+    # on_conflict: update     # or: nothing (INSERT IGNORE). Only with primary_key.
+    # batch_size: 1000
+```
+
+| Field          | Required | Description                                                                              |
+| -------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `type`         | Yes      | `mysql`                                                                                  |
+| `from`         | Yes      | Source or transform to read from                                                         |
+| `schema`       | Yes      | Database name (MySQL treats `schema` and `database` as synonyms)                         |
+| `table`        | Yes      | Table name (auto-created if missing)                                                     |
+| `secret_name`  | Yes      | Secret holding MySQL connection fields                                                   |
+| `primary_key`  | No       | Column or comma-separated list — when set, inserts become upserts (composite keys ok)    |
+| `on_conflict`  | No       | `update` (default, `ON DUPLICATE KEY UPDATE`) or `nothing` (`INSERT IGNORE`)             |
+| `batch_size`   | No       | Max rows per `INSERT` statement (default `1000`)                                         |
+
+**Secret format:** structured JSON with `host`, `port`, `user`, `password`, `databaseName`. The `goldsky secret create` flow accepts either a MySQL URL (`mysql://user:pass@host:3306/database`) or individual fields and parses them into the structured shape.
+
+**Behavior notes:**
+- Auto-creates the table on startup with `CREATE TABLE IF NOT EXISTS`. No `ALTER TABLE` — adding a new upstream column against an existing table fails the insert.
+- Rows with `_gs_op = "d"` are deleted by primary key. With no `primary_key`, deletes are a no-op.
+- Arrow → MySQL type mapping: `Int32 → INT`, `Int64 → BIGINT`, `UInt64 → BIGINT UNSIGNED`, `Float64 → DOUBLE`, `Utf8 → TEXT`, `Binary → LONGBLOB`, `Timestamp → DATETIME(6)`, `Date → DATE`, `Decimal(p,s) → DECIMAL(p,s)` (precision capped at 65), nested types (struct/list/map) → `JSON`.
 
 ---
 
@@ -198,6 +235,57 @@ sinks:
 ```
 
 **Secret format:** `access_key_id:secret_access_key` (or `access_key_id:secret_access_key:session_token` for temporary credentials)
+
+---
+
+## SQS
+
+Send each upstream row to Amazon SQS as a JSON message body. Standard queues only — FIFO queues are not supported (the sink does not set `MessageGroupId` or `MessageDeduplicationId`).
+
+```yaml
+sinks:
+  sqs_output:
+    type: sqs_sink
+    from: my_transform
+    queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/my-queue
+    secret_name: MY_SQS_SECRET
+```
+
+Inline credentials (not recommended for production):
+
+```yaml
+sinks:
+  sqs_output:
+    type: sqs_sink
+    from: my_transform
+    queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/my-queue
+    access_key_id: <your-access-key>
+    secret_access_key: <your-secret-key>
+    region: us-east-1
+    # session_token: <sts-token>   # optional, for temporary credentials
+    # endpoint_url: <custom-url>   # optional, for SQS-compatible services / VPC endpoints
+```
+
+| Field               | Required | Description                                                                          |
+| ------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `type`              | Yes      | `sqs_sink`                                                                           |
+| `from`              | Yes      | Source or transform to read from                                                     |
+| `queue_url`         | Yes      | Full SQS queue URL                                                                   |
+| `secret_name`       | Varies   | Secret holding `accessKeyId` / `secretAccessKey` / `region` (preferred)              |
+| `access_key_id`     | Varies   | Inline AWS access key (omit when using `secret_name`)                                |
+| `secret_access_key` | Varies   | Inline AWS secret (omit when using `secret_name`)                                    |
+| `region`            | Varies   | AWS region (omit when using `secret_name`)                                           |
+| `session_token`     | No       | STS / SSO / assumed-role temporary credentials                                       |
+| `endpoint_url`      | No       | Custom SQS endpoint (e.g. VPC endpoint or SQS-compatible service)                    |
+
+**Secret format** (`type: sqs`): JSON with `accessKeyId`, `secretAccessKey`, `region`, and `type: "sqs"`.
+
+**IAM:** the credentials need `sqs:SendMessage` and `sqs:SendMessageBatch` on the target queue.
+
+**Delivery behavior:**
+- Uses `SendMessageBatch` with up to 10 messages per request; larger upstream batches are split into 10-message chunks automatically.
+- Retries partial-batch failures up to 5 times with exponential backoff (100 ms → 5 s). Sender-fault failures fail immediately without retry.
+- SQS rejects messages over 256 KB — drop or truncate wide columns upstream with a SQL transform if payloads approach the limit.
 
 ---
 


### PR DESCRIPTION
## Summary

The Turbo dashboard sink dropdown lists 12 sink types. \`sink-reference.md\` was missing **MySQL** and **SQS**, even though both are supported and documented on docs.goldsky.com (\`turbo-pipelines/sinks/mysql.mdx\`, \`turbo-pipelines/sinks/sqs.mdx\`).

This PR adds them in three places:

- \`skills/turbo-pipelines/references/sink-reference.md\` — full sections (params table, secret format, behavior notes); TOC updated
- \`skills/turbo-pipelines/SKILL.md\` — Sink Selection table gains \`mysql\` and \`sqs_sink\` rows
- \`skills/turbo-builder/SKILL.md\` — Key config table gains MySQL and SQS; description trigger list now includes \`mysql\` / \`sqs\` (and \`pubsub\`)
- \`skills/turbo-pipelines/evals/trigger-eval.json\` — two new \`should_trigger\` queries

### Out of scope

The dashboard dropdown also shows **Hosted Postgres (beta)**, **DynamoDB**, **Elasticsearch**, and **OpenSearch**. None of these have public docs pages on docs.goldsky.com. The \`secrets\` skill already has secret types for DynamoDB / Elasticsearch / OpenSearch / SQS, suggesting they're supported under the hood, but I'd want product confirmation (and a public docs page) before adding them to the skill.

## Test plan

- [ ] \`goldsky turbo validate -f\` a small pipeline using \`type: mysql\` and confirm the schema accepts it
- [ ] Same for \`type: sqs_sink\`
- [ ] Spot-check that the new descriptions trigger the skill on the new eval queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)