### PR TITLE
Document webhook skip_on_error in Turbo skill

### DIFF
--- a/skills/turbo-pipelines/SKILL.md
+++ b/skills/turbo-pipelines/SKILL.md
@@ -307,6 +307,21 @@ sinks:
 
 The secret holds a GCP project id and service-account JSON. Topic must already exist in GCP.
 
+#### Webhook
+
+```yaml
+sinks:
+  webhook_alerts:
+    type: webhook
+    from: my_transform
+    url: https://api.example.com/webhook
+    secret_name: MY_WEBHOOK_SECRET # Optional httpauth secret
+    one_row_per_request: true # Optional
+    skip_on_error: true # Optional; continue past failed deliveries
+```
+
+Use `skip_on_error: true` only when missing a webhook delivery is acceptable, because failed rows are skipped instead of blocking or failing the pipeline.
+
 #### Blackhole (Testing)
 
 ```yaml

--- a/skills/turbo-pipelines/references/sink-reference.md
+++ b/skills/turbo-pipelines/references/sink-reference.md
@@ -195,7 +195,7 @@ The topic must exist in GCP before deploying the pipeline — Goldsky does not a
 
 ## Webhook
 
-Webhook sinks do **not** use Goldsky's secrets management. Include auth headers directly in the config, or use a plain URL for unauthenticated endpoints.
+Webhook sinks send rows to an HTTP endpoint with `POST`. Use `secret_name` for a Goldsky `httpauth` secret, inline `headers` for non-secret headers, or a plain URL for unauthenticated endpoints. Do not provide the same header through both `secret_name` and `headers`.
 
 ```yaml
 sinks:
@@ -203,9 +203,10 @@ sinks:
     type: webhook
     from: my_transform
     url: https://api.example.com/webhook
+    secret_name: MY_WEBHOOK_SECRET
     one_row_per_request: true
+    skip_on_error: true
     headers:
-      Authorization: Bearer your-token
       Content-Type: application/json
 ```
 
@@ -218,6 +219,16 @@ sinks:
     from: my_transform
     url: https://my-lambda.us-west-2.on.aws/
 ```
+
+| Field                 | Required | Description                                                                 |
+| --------------------- | -------- | --------------------------------------------------------------------------- |
+| `url`                 | Yes      | Fully-qualified HTTP(S) endpoint URL. Webhook sinks always use HTTP `POST`. |
+| `secret_name`         | No       | Name of a Goldsky `httpauth` secret for authenticated webhooks.             |
+| `headers`             | No       | Additional non-secret headers. Do not duplicate headers from `secret_name`. |
+| `one_row_per_request` | No       | Send one JSON object per request instead of batching rows as a JSON array.  |
+| `skip_on_error`       | No       | If `true`, failed deliveries are skipped so the pipeline continues.         |
+
+By default, retriable responses such as timeouts, `408`, `429`, and `5xx` are retried with backoff, while non-retriable `4xx` responses fail the pipeline. Set `skip_on_error: true` only when missing a delivery is acceptable, because skipped rows are not delivered to the endpoint.
 
 ---
 

--- a/skills/turbo-pipelines/references/validation-checklist.md
+++ b/skills/turbo-pipelines/references/validation-checklist.md
@@ -61,7 +61,7 @@ For each sink entry:
   - `pubsub`: `topic`, `secret_name` (Turbo-only sink)
   - `s3_sink`: `endpoint`, `bucket`, `secret_name`
   - `s2_sink`: `access_token`, `basin`, `stream`
-  - `webhook`: `url` (no `secret_name`)
+  - `webhook`: `url`; optional `secret_name`, `headers`, `one_row_per_request`, `skip_on_error`
   - `blackhole`: only `from` required
 
 ## Cross-References


### PR DESCRIPTION
## Summary
- Add `skip_on_error` to the Turbo webhook sink quick reference
- Update the detailed sink reference with webhook auth, retry, and skip behavior
- Fix the validation checklist so it no longer says webhook sinks cannot use `secret_name`

## Validation
- `git diff --check`
- `npm run validate`
