### PR TITLE
ci: sync skills to Bedrock KB on push (APP-4690)

### DIFF
--- a/.github/workflows/sync-kb.yml
+++ b/.github/workflows/sync-kb.yml
@@ -1,0 +1,71 @@
+# goldsky-io/goldsky-agent repository. APP-4690.
+name: Sync to Bedrock KB
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+  S3_BUCKET: goldsky-kb-prod
+  KB_ID: ${{ secrets.BEDROCK_KB_ID_PROD }}
+  DATA_SOURCE_ID: ${{ secrets.BEDROCK_DATA_SOURCE_SKILLS_ID_PROD }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/goldsky-kb-prod-gha-ingest
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync skills/ to S3
+        run: |
+          aws s3 sync skills/ s3://$S3_BUCKET/skills/ \
+            --delete
+
+      - name: Trigger Bedrock ingestion job
+        run: |
+          JOB_ID=$(aws bedrock-agent start-ingestion-job \
+            --knowledge-base-id "$KB_ID" \
+            --data-source-id "$DATA_SOURCE_ID" \
+            --description "Triggered by ${GITHUB_SHA::7} on $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --query 'ingestionJob.ingestionJobId' \
+            --output text)
+          echo "Started ingestion job: $JOB_ID"
+          echo "JOB_ID=$JOB_ID" >> "$GITHUB_ENV"
+
+      - name: Wait for ingestion to complete
+        run: |
+          for i in {1..60}; do
+            STATUS=$(aws bedrock-agent get-ingestion-job \
+              --knowledge-base-id "$KB_ID" \
+              --data-source-id "$DATA_SOURCE_ID" \
+              --ingestion-job-id "$JOB_ID" \
+              --query 'ingestionJob.status' \
+              --output text)
+            echo "[$i/60] Status: $STATUS"
+            if [ "$STATUS" = "COMPLETE" ]; then exit 0; fi
+            if [ "$STATUS" = "FAILED" ]; then
+              aws bedrock-agent get-ingestion-job \
+                --knowledge-base-id "$KB_ID" \
+                --data-source-id "$DATA_SOURCE_ID" \
+                --ingestion-job-id "$JOB_ID"
+              exit 1
+            fi
+            sleep 30
+          done
+          echo "Timed out waiting for ingestion"
+          exit 1

--- a/.github/workflows/sync-kb.yml
+++ b/.github/workflows/sync-kb.yml
@@ -39,6 +39,12 @@ env:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Serialize runs per environment so two pushes can't race the S3 sync /
+    # overlap ingestion jobs on the same data source; don't cancel an in-flight
+    # ingestion.
+    concurrency:
+      group: sync-kb-${{ github.workflow }}-${{ matrix.environment }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -63,11 +69,11 @@ jobs:
 
       - name: Checkout
         if: steps.kb.outputs.active == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AWS credentials via OIDC
         if: steps.kb.outputs.active == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::${{ steps.kb.outputs.account }}:role/goldsky-kb-${{ matrix.environment }}-gha-ingest
           aws-region: ${{ env.AWS_REGION }}
@@ -76,6 +82,7 @@ jobs:
         if: steps.kb.outputs.active == 'true'
         run: |
           aws s3 sync skills/ "s3://goldsky-kb-${{ matrix.environment }}/skills/" \
+            --exclude "*.sh" \
             --delete
 
       - name: Trigger + wait for ingestion (${{ matrix.environment }})

--- a/.github/workflows/sync-kb.yml
+++ b/.github/workflows/sync-kb.yml
@@ -1,4 +1,16 @@
-# goldsky-io/goldsky-agent repository. APP-4690.
+# Syncs this repo's skills/ content to the Goldsky AI chatbot's Bedrock KB
+# ingest buckets and triggers a Knowledge Base ingestion job.
+# goldsky-io/goldsky-agent repository.
+#
+# Dual-write: there is one KB per environment (dev + prod), each in its own AWS
+# account, and they are kept in sync by syncing to BOTH on every run. Each
+# environment leg activates only when its per-environment repo secrets are set,
+# so prod turns on automatically once its secrets are added — no workflow change.
+#
+# Auth is GitHub OIDC into the per-account `goldsky-kb-<env>-gha-ingest` role,
+# whose trust policy only allows `refs/heads/main`, so this runs on main (push
+# or manual dispatch), not on feature branches. Account ids come from secrets
+# (not committed to this public repo).
 name: Sync to Bedrock KB
 
 on:
@@ -14,29 +26,63 @@ permissions:
 
 env:
   AWS_REGION: us-west-2
-  S3_BUCKET: goldsky-kb-prod
-  KB_ID: ${{ secrets.BEDROCK_KB_ID_PROD }}
-  DATA_SOURCE_ID: ${{ secrets.BEDROCK_DATA_SOURCE_SKILLS_ID_PROD }}
+  # Per-environment config from repo secrets. An env whose KB-id or account-id
+  # secret is empty is skipped (see the resolve step), so prod stays inert until
+  # its secrets exist.
+  KB_ID_DEV: ${{ secrets.BEDROCK_KB_ID_DEV }}
+  KB_ID_PROD: ${{ secrets.BEDROCK_KB_ID_PROD }}
+  DS_ID_DEV: ${{ secrets.BEDROCK_DATA_SOURCE_SKILLS_ID_DEV }}
+  DS_ID_PROD: ${{ secrets.BEDROCK_DATA_SOURCE_SKILLS_ID_PROD }}
+  ACCOUNT_DEV: ${{ secrets.AWS_ACCOUNT_ID_DEV }}
+  ACCOUNT_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, prod]
     steps:
+      - name: Resolve KB target for ${{ matrix.environment }}
+        id: kb
+        run: |
+          case "${{ matrix.environment }}" in
+            dev)  KB_ID="$KB_ID_DEV";  DS_ID="$DS_ID_DEV";  ACCOUNT="$ACCOUNT_DEV"  ;;
+            prod) KB_ID="$KB_ID_PROD"; DS_ID="$DS_ID_PROD"; ACCOUNT="$ACCOUNT_PROD" ;;
+          esac
+          if [ -z "$KB_ID" ] || [ -z "$ACCOUNT" ]; then
+            echo "Missing secrets for ${{ matrix.environment }} — skipping."
+            echo "active=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "active=true" >> "$GITHUB_OUTPUT"
+            echo "kb_id=$KB_ID" >> "$GITHUB_OUTPUT"
+            echo "ds_id=$DS_ID" >> "$GITHUB_OUTPUT"
+            echo "account=$ACCOUNT" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+        if: steps.kb.outputs.active == 'true'
         uses: actions/checkout@v4
 
       - name: Configure AWS credentials via OIDC
+        if: steps.kb.outputs.active == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/goldsky-kb-prod-gha-ingest
+          role-to-assume: arn:aws:iam::${{ steps.kb.outputs.account }}:role/goldsky-kb-${{ matrix.environment }}-gha-ingest
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Sync skills/ to S3
+      - name: Sync skills/ to S3 (${{ matrix.environment }})
+        if: steps.kb.outputs.active == 'true'
         run: |
-          aws s3 sync skills/ s3://$S3_BUCKET/skills/ \
+          aws s3 sync skills/ "s3://goldsky-kb-${{ matrix.environment }}/skills/" \
             --delete
 
-      - name: Trigger Bedrock ingestion job
+      - name: Trigger + wait for ingestion (${{ matrix.environment }})
+        if: steps.kb.outputs.active == 'true'
+        env:
+          KB_ID: ${{ steps.kb.outputs.kb_id }}
+          DATA_SOURCE_ID: ${{ steps.kb.outputs.ds_id }}
         run: |
           JOB_ID=$(aws bedrock-agent start-ingestion-job \
             --knowledge-base-id "$KB_ID" \
@@ -44,11 +90,7 @@ jobs:
             --description "Triggered by ${GITHUB_SHA::7} on $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --query 'ingestionJob.ingestionJobId' \
             --output text)
-          echo "Started ingestion job: $JOB_ID"
-          echo "JOB_ID=$JOB_ID" >> "$GITHUB_ENV"
-
-      - name: Wait for ingestion to complete
-        run: |
+          echo "Started ingestion job $JOB_ID (${{ matrix.environment }})"
           for i in {1..60}; do
             STATUS=$(aws bedrock-agent get-ingestion-job \
               --knowledge-base-id "$KB_ID" \


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sync-kb.yml`. On push to `main` touching `skills/**`
(or manual `workflow_dispatch`), the workflow assumes an AWS role via GitHub
OIDC, mirrors `skills/` to the chatbot's Bedrock Knowledge Base ingest S3
bucket (`--delete`), triggers a Bedrock ingestion job on the skills data
source, and polls until it reaches `COMPLETE` or `FAILED`.

This keeps the assistant's retrieval knowledge base in sync with this repo's
skill content. It **adds only an S3 sync + ingestion trigger** — it changes no
skill content and touches no files runtime consumers read, so it is transparent
to them.

## Dual-write (dev + prod)

There is one knowledge base per environment, each in its own AWS account. The
workflow syncs to **both** on every run so they stay in sync, using a matrix
over `dev` and `prod`. Each environment leg activates only when its
per-environment repo secrets are present, so an unconfigured environment is
skipped (the job is green with skipped steps) and turns on automatically once
its secrets are added — no workflow change needed.

## Required repo secrets

Per environment (`_DEV` / `_PROD`):

- `AWS_ACCOUNT_ID_<ENV>` — account hosting that environment's KB.
- `BEDROCK_KB_ID_<ENV>` — the knowledge base id.
- `BEDROCK_DATA_SOURCE_SKILLS_ID_<ENV>` — the skills data-source id.

The per-account `goldsky-kb-<env>-gha-ingest` OIDC role and the data sources are
provisioned by infrastructure-as-code; the role's trust policy allows
`repo:goldsky-io/goldsky-agent:ref:refs/heads/main`.

## Testing

With an environment's secrets set and its KB provisioned, trigger via **Run
workflow** (`workflow_dispatch`) on `main`: confirm the S3 sync succeeds, an
ingestion job starts, and the poll reaches `COMPLETE`.
