### PR TITLE
cli-reference sweep: complete coverage (db, compose) + install info

### DIFF
--- a/scripts/generate-cli-reference.js
+++ b/scripts/generate-cli-reference.js
@@ -417,7 +417,7 @@ function main() {
   // Frontmatter
   sections.push(`---
 name: cli-reference
-description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, db, project, dataset, indexed, telemetry, and compose. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
+description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, project, dataset, indexed, telemetry, and compose. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
 ---
 
 # Goldsky CLI Reference
@@ -460,8 +460,12 @@ goldsky compose update
   // turbo (from binary)
   sections.push(renderTurboSection());
 
-  // TypeScript CLI command groups
-  const groups = ["pipeline", "subgraph", "secret", "db", "project", "dataset", "indexed", "telemetry"];
+  // TypeScript CLI command groups.
+  // NOTE: `db` is intentionally excluded — it is registered as a hidden command
+  // (`.command("db", false, ...)` in the CLI entrypoint, so it never appears in
+  // `goldsky --help`). We document only surfaced commands. Likewise `chat` is an
+  // unregistered source module (no `.command()`), so it is not a real command.
+  const groups = ["pipeline", "subgraph", "secret", "project", "dataset", "indexed", "telemetry"];
   groups.forEach((verb) => {
     const dir = path.join(COMMANDS_DIR, verb);
     if (!fs.existsSync(dir)) return;

--- a/scripts/generate-cli-reference.js
+++ b/scripts/generate-cli-reference.js
@@ -232,7 +232,7 @@ function parseTurboHelp(helpText) {
 
 function renderTurboSection() {
   const lines = ["## goldsky turbo\n"];
-  lines.push("Manages Turbo streaming pipelines. Delegates to the `turbo` binary.\n");
+  lines.push("Manages Turbo streaming pipelines. Delegates to the `turbo` binary, which is auto-installed on first use — or manually via `curl https://install-turbo.goldsky.com | sh` (see Installation).\n");
 
   let topHelp;
   try {
@@ -298,6 +298,47 @@ function renderTurboSection() {
 
     lines.push(section.join("\n"));
   });
+
+  return lines.join("\n");
+}
+
+// ── Compose (passthrough binary, separate Compose CLI) ──────────────────────
+
+function stripAnsi(str) {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderComposeSection() {
+  const lines = ["## goldsky compose\n"];
+  lines.push(
+    "Build and deploy offchain-to-onchain TypeScript tasks. `goldsky compose` delegates to the standalone Compose CLI (auto-installed on first use, or manually via `curl -fsSL https://compose.goldsky.com/install | sh` — see Installation). For manifest fields, every flag, and the `TaskContext` API, see the **compose-reference** skill; to build one interactively, use the **compose** skill.\n"
+  );
+
+  let help;
+  try {
+    help = execSync("goldsky compose --help 2>&1", { encoding: "utf8" });
+  } catch (e) {
+    lines.push("*Could not run `goldsky compose --help` — is the CLI installed?*");
+    return lines.join("\n");
+  }
+
+  const clean = stripAnsi(stripBanner(help));
+  const cmds = [];
+  const cmdSection = clean.match(/Commands:\s*\n([\s\S]*)/);
+  if (cmdSection) {
+    cmdSection[1].split("\n").forEach((l) => {
+      const m = l.match(/^\s{2,}([a-zA-Z][\w-]*)\b.*?-\s+(.+?)\s*$/);
+      if (m && m[1] !== "help") cmds.push({ name: m[1], describe: m[2].trim() });
+    });
+  }
+
+  if (cmds.length) {
+    lines.push("### Subcommands\n");
+    lines.push("Run `goldsky compose <cmd> --help` for flags; full details live in the compose-reference skill.\n");
+    cmds.forEach(({ name, describe }) => lines.push(`- \`goldsky compose ${name}\` — ${describe}`));
+    lines.push("");
+  }
 
   return lines.join("\n");
 }
@@ -376,13 +417,37 @@ function main() {
   // Frontmatter
   sections.push(`---
 name: cli-reference
-description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, project, dataset, indexed, and telemetry. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
+description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, db, project, dataset, indexed, telemetry, and compose. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
 ---
 
 # Goldsky CLI Reference
 
 > Auto-generated from the Goldsky CLI source and turbo binary (${turboVersion}).
 > Re-run \`node scripts/generate-cli-reference.js\` to update.
+`);
+
+  // Installation (base CLI + delegated turbo/compose binaries)
+  sections.push(`## Installation
+
+Install the base Goldsky CLI (provides \`goldsky\`):
+
+\`\`\`bash
+curl https://goldsky.com | sh
+\`\`\`
+
+\`goldsky turbo\` and \`goldsky compose\` delegate to separate binaries that are installed automatically on first use (the CLI prompts you). To install or update them manually:
+
+\`\`\`bash
+# Turbo — macOS / Linux
+curl https://install-turbo.goldsky.com | sh
+# Turbo — Windows
+irm https://install-turbo.goldsky.com/scripts/install.ps1 | iex
+
+# Compose (installs to ~/.goldsky/bin/compose)
+curl -fsSL https://compose.goldsky.com/install | sh
+# Update Compose later
+goldsky compose update
+\`\`\`
 `);
 
   // Top-level commands (login/logout are simple, no options worth documenting)
@@ -396,12 +461,15 @@ description: "Goldsky CLI command and flag reference — all valid subcommands, 
   sections.push(renderTurboSection());
 
   // TypeScript CLI command groups
-  const groups = ["pipeline", "subgraph", "secret", "project", "dataset", "indexed", "telemetry"];
+  const groups = ["pipeline", "subgraph", "secret", "db", "project", "dataset", "indexed", "telemetry"];
   groups.forEach((verb) => {
     const dir = path.join(COMMANDS_DIR, verb);
     if (!fs.existsSync(dir)) return;
     sections.push(renderGroup(verb, dir));
   });
+
+  // compose (passthrough to the standalone Compose CLI; no TS source dir)
+  sections.push(renderComposeSection());
 
   fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
   fs.writeFileSync(OUTPUT, sections.join("\n---\n\n"));

--- a/skills/cli-reference/SKILL.md
+++ b/skills/cli-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-reference
-description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, db, project, dataset, indexed, telemetry, and compose. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
+description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, project, dataset, indexed, telemetry, and compose. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
 ---
 
 # Goldsky CLI Reference
@@ -522,22 +522,6 @@ update a secret
 **Options:**
 - `--value <string>` — the new value of the secret
 - `--description <string>` — the new description of the secret
-
----
-
-## goldsky db
-
-Commands related to Goldsky DB
-
-### Subcommands
-
-#### `goldsky db clickhouse`
-
-Commands related to Goldsky ClickHouse
-
-##### `goldsky db clickhouse connect`
-
-Connect to your Goldsky ClickHouse database
 
 ---
 

--- a/skills/cli-reference/SKILL.md
+++ b/skills/cli-reference/SKILL.md
@@ -1,12 +1,36 @@
 ---
 name: cli-reference
-description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, project, dataset, indexed, and telemetry. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
+description: "Goldsky CLI command and flag reference — all valid subcommands, arguments, and options for goldsky turbo, pipeline, subgraph, secret, db, project, dataset, indexed, telemetry, and compose. Consult before suggesting any goldsky command to avoid hallucinating invalid commands or flags."
 ---
 
 # Goldsky CLI Reference
 
 > Auto-generated from the Goldsky CLI source and turbo binary (turbo 0.9.1).
 > Re-run `node scripts/generate-cli-reference.js` to update.
+
+---
+
+## Installation
+
+Install the base Goldsky CLI (provides `goldsky`):
+
+```bash
+curl https://goldsky.com | sh
+```
+
+`goldsky turbo` and `goldsky compose` delegate to separate binaries that are installed automatically on first use (the CLI prompts you). To install or update them manually:
+
+```bash
+# Turbo — macOS / Linux
+curl https://install-turbo.goldsky.com | sh
+# Turbo — Windows
+irm https://install-turbo.goldsky.com/scripts/install.ps1 | iex
+
+# Compose (installs to ~/.goldsky/bin/compose)
+curl -fsSL https://compose.goldsky.com/install | sh
+# Update Compose later
+goldsky compose update
+```
 
 ---
 
@@ -19,7 +43,7 @@ description: "Goldsky CLI command and flag reference — all valid subcommands, 
 
 ## goldsky turbo
 
-Manages Turbo streaming pipelines. Delegates to the `turbo` binary.
+Manages Turbo streaming pipelines. Delegates to the `turbo` binary, which is auto-installed on first use — or manually via `curl https://install-turbo.goldsky.com | sh` (see Installation).
 
 ### Subcommands
 
@@ -501,6 +525,22 @@ update a secret
 
 ---
 
+## goldsky db
+
+Commands related to Goldsky DB
+
+### Subcommands
+
+#### `goldsky db clickhouse`
+
+Commands related to Goldsky ClickHouse
+
+##### `goldsky db clickhouse connect`
+
+Connect to your Goldsky ClickHouse database
+
+---
+
 ## goldsky project
 
 Commands related to project management
@@ -694,3 +734,24 @@ Enable anonymous CLI telemetry
 #### `goldsky telemetry status`
 
 Display the CLI telemetry status
+
+---
+
+## goldsky compose
+
+Build and deploy offchain-to-onchain TypeScript tasks. `goldsky compose` delegates to the standalone Compose CLI (auto-installed on first use, or manually via `curl -fsSL https://compose.goldsky.com/install | sh` — see Installation). For manifest fields, every flag, and the `TaskContext` API, see the **compose-reference** skill; to build one interactively, use the **compose** skill.
+
+### Subcommands
+
+Run `goldsky compose <cmd> --help` for flags; full details live in the compose-reference skill.
+
+- `goldsky compose deploy` — Deploy tasks to the server
+- `goldsky compose start` — Start the server with the given configuration
+- `goldsky compose dev` — Start the server in development mode
+- `goldsky compose callTask` — Calls a locally running task with a json payload
+- `goldsky compose init` — Initialize a new Compose app with Bitcoin price oracle
+- `goldsky compose secret` — Compose secrets
+- `goldsky compose bundle` — Bundle task scripts without starting the server
+- `goldsky compose codegen` — Generate TypeScript classes from contract ABIs in src/contracts
+- `goldsky compose clean` — Bundle task scripts without starting the server
+- `goldsky compose update` — Update Compose CLI to the latest version


### PR DESCRIPTION
## What

A full accuracy + completeness sweep of the `cli-reference` skill, combing the entire `goldsky` CLI (v13.3.4 source + the `turbo` 0.9.1 / `compose` 0.3.0 binaries).

## Accuracy: already clean
Re-running the generator against the current 13.3.4 source produced **zero drift** for the existing groups + turbo — the committed reference was already accurate and current. No corrections needed there.

## Completeness: what changed
Combing the CLI (and its command registration in the entrypoint) clarified what's actually exposed:

| Command | Exposed? | Action |
| --- | --- | --- |
| **`goldsky compose`** | Yes (`.command(compose)`) — was missing from the reference | **Added.** Generator renders it from `goldsky compose --help` (passthrough to the standalone Compose CLI); lists subcommands and points to the `compose-reference` skill for flag detail. |
| **`goldsky db`** | **No — hidden** (`.command("db", false, ...)`; excluded from `goldsky --help`) | **Excluded.** Documented only surfaced commands; generator annotated so it stays out. |
| **`goldsky chat`** | **No — unregistered** (source module exists but no `.command()` wiring) | **Excluded.** Not a real command. |
| Install instructions | n/a | **Added** an Installation section + inline one-liners. |

So the net additions are: an **Installation** section and the **`goldsky compose`** section.

## Install commands (verified from CLI source, not guessed)
- Base CLI: `curl https://goldsky.com | sh`
- Turbo: `curl https://install-turbo.goldsky.com | sh` (Windows: `irm https://install-turbo.goldsky.com/scripts/install.ps1 | iex`) — auto-prompts on first `goldsky turbo` use
- Compose: `curl -fsSL https://compose.goldsky.com/install | sh` → `~/.goldsky/bin/compose`; `goldsky compose update` to update

## How it was done
Changes are in the **generator** (`scripts/generate-cli-reference.js`), not hand-edited into the output — so they survive the next regeneration (the file is stamped "auto-generated; re-run to update"). The group list is annotated to keep the hidden `db` and unregistered `chat` out. Regeneration is idempotent. Frontmatter description updated to include `compose`.

## Verification
- Generator re-run = no further drift (idempotent).
- `compose` section cross-checked against live `--help`.
- Exposure of each command confirmed against the CLI's `.command()` registration in the entrypoint (this is how `db`=hidden and `chat`=unregistered were caught).
- Base install command consistent with the `auth-setup` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)