### PR TITLE
Address Paymahn's review: subgraph perf + doctor log guidance

### DIFF
--- a/skills/subgraph-builder/references/performance.md
+++ b/skills/subgraph-builder/references/performance.md
@@ -6,7 +6,7 @@ Tuning knobs for faster indexing and queries on Goldsky-hosted subgraphs. Most a
 
 - **Permanent RPC call cache.** Goldsky permanently caches subgraph RPC calls, so re-syncs of the same or similar subgraph are much faster (cached `eth_call`/log results are reused). You generally don't need to engineer around RPC cost on a resync.
 - **Grafting fully supported** (start a new version from an existing one's data — see schema-and-mappings.md). Note the optimization tradeoff below.
-- **Goldsky can scale your indexer resources.** If a subgraph is slow because of heavy per-event work you *can't* easily restructure (e.g. a migrated/over-modeled subgraph), asking support to allocate more indexing resources is often the **highest-leverage, zero-resync** option — consider it before a costly rebuild, not just as a last resort. Indexing speed otherwise depends on subgraph design (the knobs below).
+- **Indexer resources are not the bottleneck.** Goldsky indexers are not resource-starved, and "ask for more indexing resources" is not a lever (it only ever applied to dedicated indexing, which is being deprecated). Slow indexing is almost always **subgraph design** (heavy per-event work, `eth_calls`, large stored arrays — the knobs below) or **upstream RPC performance**. Fix the design or the RPC path; don't expect more resources to help.
 - **Every version is billed separately** (worker fee + entity storage). Delete old versions you no longer query — this is the cheapest, highest-impact "optimization."
 
 ## Immutable entities + Bytes IDs
@@ -70,7 +70,7 @@ A user who wants their subgraph to "go faster without re-indexing from scratch" 
 - **The biggest speedups break graft compatibility.** Making entities immutable, changing entity storage, or restructuring the schema all change the schema, and **you can't graft across a schema change.** So you can optimize hard *or* graft-to-skip-resync — not both.
 - **Graft-safe changes** are manifest-level and mapping-internal only: declaring `eth_calls`, trimming work inside handlers, removing an unused handler. These keep the schema identical, so a graft is valid — but they often don't touch a design-bound bottleneck (e.g. per-swap USD pricing).
 
-If the only changes that would meaningfully help require schema/storage changes, the realistic options are: ask support to scale indexer resources (no resync), or rebuild leaner and resync from scratch (below).
+If the only changes that would meaningfully help require schema/storage changes, the realistic option is to rebuild leaner and resync from scratch (below). There is no "add more resources" shortcut — the slowness is the design.
 
 ## Optimizing a migrated or over-modeled subgraph
 

--- a/skills/subgraph-doctor/SKILL.md
+++ b/skills/subgraph-doctor/SKILL.md
@@ -59,15 +59,14 @@ Subgraph problems fall into a few families. Pick the path that matches the sympt
 Run these and analyze before concluding:
 
 ```bash
-# Recent errors (widen the window if nothing shows)
+# Errors only — START HERE. Widen the window (e.g. --since 24h) if nothing shows.
 goldsky subgraph log <name/version> --since 1h --filter error 2>&1
-
-# Full recent context, not just errors
-goldsky subgraph log <name/version> --since 1h 2>&1
 
 # Subgraph + tag + deployment status
 goldsky subgraph list <name/version> 2>&1
 ```
+
+> **Do not pull unfiltered logs.** Subgraphs emit a huge volume at `info`/`debug` level — running `goldsky subgraph log` without `--filter error` is slow and extremely token-hungry, and rarely adds signal over the error-filtered view. If you genuinely need non-error context, scope it tightly: a very short window (`--since 5m`) and, if possible, grep for a specific string. Lead with errors + the `_meta` query below.
 
 Then run the **`_meta` query** against the GraphQL endpoint — this is the single most useful check for "stuck" or "no data" subgraphs. It reports the latest indexed block:
 


### PR DESCRIPTION
Addresses [Paymahn's review feedback on #32](https://github.com/goldsky-io/goldsky-agent/pull/32) (now merged), in a follow-up PR.

## Changes

**1 & 2 — "scale indexer resources" was wrong (`performance.md`)**
> _paymog:_ "we don't do this except for folks on dedicated indexing which we're in general deprecating" / "indexers are never resource starved, it's usually bad subgraph design or poor rpc performance"

Removed both instances that suggested asking support to allocate more indexing resources. Reframed accurately: Goldsky indexers aren't resource-starved, so "more resources" isn't a lever — slow indexing is **subgraph design** or **upstream RPC performance**, and the fix is to improve the design/RPC or rebuild leaner. No "add resources" shortcut.

**3 — unfiltered logs are token-hungry (`subgraph-doctor`)**
> _paymog:_ "this can be insanely token hungry because subgraphs emit a TON of logs at debug and info level"

The doctor's Step 4 no longer instructs an unfiltered `goldsky subgraph log` pull. It now leads with `--filter error` only, and adds an explicit caution: don't pull unfiltered info/debug logs (huge volume, slow, token-hungry); if non-error context is genuinely needed, scope it tightly (`--since 5m`, grep for a string). Errors + the `_meta` query remain the primary signals.

## Notes
- All three are accuracy/quality fixes to skill content; no routing/description changes (trigger evals unaffected).
- Grepped the full subgraph skill set to confirm these were the only occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)