### PR TITLE
feat(skills): router skill + docs-MCP pointers (Wave 0, APP-4964)

### DIFF
--- a/skills/auth-setup/SKILL.md
+++ b/skills/auth-setup/SKILL.md
@@ -5,6 +5,8 @@ description: "Set up Goldsky CLI authentication and project configuration. Use t
 
 # Goldsky Authentication & Project Setup
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Set up the Goldsky CLI, authenticate your account, and configure projects for your pipelines and subgraphs.
 
 ## Prerequisites

--- a/skills/compose-doctor/SKILL.md
+++ b/skills/compose-doctor/SKILL.md
@@ -5,6 +5,8 @@ description: "Diagnose and fix broken Goldsky Compose apps interactively. Trigge
 
 # Compose Doctor
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Diagnose and fix broken Compose apps. Workflow-oriented: we walk through auth → app identification → status → logs → secrets → wallets → manifest → diagnosis → fix.
 
 ## Boundaries

--- a/skills/compose/SKILL.md
+++ b/skills/compose/SKILL.md
@@ -5,6 +5,8 @@ description: "Use this skill when the user asks about Goldsky Compose — the of
 
 # Goldsky Compose
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Goldsky Compose is the offchain-to-onchain framework for high-stakes systems. Write TypeScript **tasks** that run in verifiable sandboxes — triggered by cron, HTTP, or onchain events — with smart wallets, gas sponsorship, and durable collections. Typical use cases: custom price oracles, keepers, circuit breakers, prediction-market resolvers, cross-chain automation, identity/attestation flows, and notifications.
 
 ## Boundaries

--- a/skills/goldsky/SKILL.md
+++ b/skills/goldsky/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: goldsky
+description: "Goldsky entry point and reference router. Trigger for cross-cutting Goldsky reference questions (dataset names, sink/secret fields, CLI flags, SQL functions, chain prefixes, pipeline states) and when a docs/reference lookup is failing or the right tool is unclear. Do NOT trigger when the task maps to a specific recipe — building or fixing a Turbo/Mirror pipeline, building or fixing a subgraph, building or fixing a Compose app, or CLI auth — use that skill instead."
+---
+
+# Goldsky
+
+## Reference questions → the docs
+For anything factual (dataset names, sink/secret fields, CLI flags, SQL
+functions, chain prefixes, pipeline states), search the **Goldsky docs MCP**,
+or browse https://docs.goldsky.com. The docs are the source of truth.
+
+**No docs MCP available?** Install it (one-time):
+https://docs.goldsky.com/mcp-server
+
+## Task → recipe routing
+| The user wants to… | Use skill |
+| --- | --- |
+| Build a Turbo pipeline | `turbo-builder` |
+| Fix a broken Turbo pipeline | `turbo-doctor` |
+| Write a SQL/TS/dynamic transform | `turbo-transforms` |
+| Fix a broken Mirror pipeline | `mirror-doctor` |
+| Build a Compose app | `compose` |
+| Fix a broken Compose app | `compose-doctor` |
+| Build/deploy a subgraph | `subgraph-builder` |
+| Fix a broken subgraph | `subgraph-doctor` |
+| Migrate a subgraph from The Graph | `subgraph-migrate` |
+| Set up the CLI / log in | `auth-setup` |
+| Get a managed RPC endpoint | see https://docs.goldsky.com/edge-rpc |

--- a/skills/mirror-doctor/SKILL.md
+++ b/skills/mirror-doctor/SKILL.md
@@ -5,6 +5,8 @@ description: "Diagnose and fix broken Goldsky Mirror pipelines. Use this skill w
 
 # Mirror Pipeline Doctor
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Diagnose and fix existing Mirror pipeline problems by running CLI commands, identifying root causes, and executing fixes.
 
 ## Boundaries

--- a/skills/subgraph-builder/SKILL.md
+++ b/skills/subgraph-builder/SKILL.md
@@ -5,6 +5,8 @@ description: "Build, author, and deploy Goldsky Subgraphs — hosted GraphQL API
 
 # Subgraph Builder
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Build a Goldsky Subgraph end-to-end: design the schema, write mappings, configure the manifest, then build and deploy to a hosted GraphQL endpoint. Subgraphs are best for **dApp frontends and apps that need flexible GraphQL queries** over structured onchain data. Subgraphs are **EVM-only**.
 
 > **Default to Turbo unless the user specifically needs GraphQL.**

--- a/skills/subgraph-doctor/SKILL.md
+++ b/skills/subgraph-doctor/SKILL.md
@@ -5,6 +5,8 @@ description: "Diagnose and fix broken Goldsky Subgraphs. Use this skill whenever
 
 # Subgraph Doctor
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Diagnose and fix existing Goldsky Subgraph problems by running CLI commands, reading logs, identifying root causes, and executing fixes.
 
 ## Boundaries

--- a/skills/subgraph-migrate/SKILL.md
+++ b/skills/subgraph-migrate/SKILL.md
@@ -5,6 +5,8 @@ description: "Migrate a subgraph from The Graph to Goldsky as a drop-in replacem
 
 # Migrate a Subgraph from The Graph
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Migrating an existing subgraph from The Graph to Goldsky is a **drop-in replacement** — you don't change your subgraph code. You point Goldsky at your published subgraph (by URL or IPFS hash) or redeploy from source, then swap the endpoint your app queries.
 
 > **Worth a quick check first: do they still need a subgraph?**

--- a/skills/turbo-builder/SKILL.md
+++ b/skills/turbo-builder/SKILL.md
@@ -5,6 +5,8 @@ description: "Build and deploy new Goldsky Turbo pipelines from scratch. Trigger
 
 # Pipeline Builder
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 ## Boundaries
 
 - Build NEW pipelines. Do not diagnose broken pipelines — that belongs to `/turbo-doctor`.

--- a/skills/turbo-doctor/SKILL.md
+++ b/skills/turbo-doctor/SKILL.md
@@ -5,6 +5,8 @@ description: "Diagnose and fix broken Goldsky Turbo pipelines interactively. Tri
 
 # Pipeline Doctor
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 ## Boundaries
 
 - Diagnose and fix EXISTING pipeline problems interactively.

--- a/skills/turbo-transforms/SKILL.md
+++ b/skills/turbo-transforms/SKILL.md
@@ -5,6 +5,8 @@ description: "Write SQL, TypeScript, and dynamic table transforms for Turbo pipe
 
 # Turbo Transforms
 
+> **Reference lookups:** for exact fields/flags/functions, search the Goldsky docs MCP or see https://docs.goldsky.com. No MCP? https://docs.goldsky.com/mcp-server
+
 Write, understand, and debug SQL, TypeScript, and dynamic table transforms for Turbo pipeline configurations.
 
 Identify what the user needs (decode, filter, reshape, combine, custom logic, or lookup joins), then use the relevant section below. If generating a complete pipeline YAML (not just a transform snippet), always validate with `goldsky turbo validate` before presenting it to the user.


### PR DESCRIPTION
**Phase B / Wave 0** of the skills↔docs rebalance — additive only, no deletions. Safe to merge anytime.

- Adds `skills/goldsky/SKILL.md` — a thin router/index: routes intents to recipe skills, sends reference questions to the docs/docs-MCP, and nudges MCP install. Description scoped with a "Do NOT trigger" clause so it doesn't hijack the specific recipes.
- Adds a one-line "Reference lookups → docs MCP" pointer to all 10 recipe headers (turbo-builder, turbo-doctor, turbo-transforms, mirror-doctor, compose, compose-doctor, subgraph-builder, subgraph-doctor, subgraph-migrate, auth-setup).

11 files, +49/-0. Reviewed for spec compliance + quality (router description tightened per review).

Tracks APP-4964.