### PR TITLE
Add compose-dividend-distribution skill + align all worked-example templates to the compose hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ AI-powered tools for the full Goldsky product surface. Build, deploy, and debug 
 | Build a Compose app (oracle / keeper / automation)    | `/compose`           |
 | Build a BTC/USD price oracle (worked example)         | `/compose-bitcoin-oracle` |
 | Build onchain verifiable randomness (worked example)  | `/compose-vrf`       |
+| Distribute a dividend / corporate action pro-rata     | `/compose-dividend-distribution` |
 | Get a fast, reliable RPC endpoint                     | `/edge`              |
 | Find the right dataset name                           | `/datasets`          |
 | Look up Turbo YAML syntax                             | `/turbo-pipelines`   |
@@ -181,6 +182,7 @@ End-to-end worked examples — each carries the full app source and walks build 
 | ----- | ----------- | ------------ |
 | `compose-bitcoin-oracle` | "Build a BTC/USD price oracle that writes onchain" | Cron task → CoinGecko → `PriceOracle` contract via a Compose wallet; collection for history |
 | `compose-vrf` | "Build a verifiable random function / onchain randomness" | Event-triggered task → drand beacon → `fulfillRandomness` on a `RandomnessConsumer` contract, verifiable by anyone |
+| `compose-dividend-distribution` | "Distribute dividends / a corporate action to token holders pro-rata" | HTTP task orchestrates a Turbo job-mode pipeline to snapshot holders at a record block, then pays each pro-rata onchain (CLI-driven) |
 
 ### Edge (managed RPC)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -30,6 +30,7 @@ _Legacy streaming product — prefer Turbo for new pipelines unless you need a s
 End-to-end worked examples — each carries the full app source and walks build → deploy → smoke test, off the shelf or customized. For a custom app that isn't one of these, use **compose**.
 - **compose-bitcoin-oracle** - Cron task writing BTC/USD from CoinGecko to an onchain `PriceOracle` contract
 - **compose-vrf** - Fetches verifiable randomness from drand and fulfills onchain `RandomnessRequested` events
+- **compose-dividend-distribution** - Pays token holders pro-rata for a corporate action; Compose orchestrates a Turbo job-mode pipeline to snapshot holders, then pays each onchain
 
 ### Edge (managed RPC)
 - **edge** - Managed RPC endpoints, capabilities, supported chains, error code lookups

--- a/skills/compose-bitcoin-oracle/SKILL.md
+++ b/skills/compose-bitcoin-oracle/SKILL.md
@@ -7,20 +7,19 @@ description: "Build and deploy the Goldsky Compose bitcoin-oracle example under 
 
 Stand up the bitcoin-oracle example under the user's own Goldsky account. A cron task fetches BTC/USD from CoinGecko and writes `(timestamp, price * 100)` as two `bytes32` values to a `PriceOracle` contract via a Compose-managed wallet. It also appends the price to a Compose `collection` for historical queries.
 
-This skill is the single source of truth for the procedure. It merges the runnable example in `goldsky-io/documentation-examples` (`compose/bitcoin-oracle`) with the in-app seed-prompt flow. The recommended path uses a **shared, fully-unpermissioned `PriceOracle` on Base Sepolia**, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored. Assume the user has never used Goldsky Compose before. Do not skip preflight.
+This template supplies only what's specific to the bitcoin-oracle app — how it works and its source. It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes — consult before writing any `compose.yaml` or task) govern this build and are not repeated here. The recommended path uses a **shared, fully-unpermissioned `PriceOracle` on Base Sepolia**, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
 
 ## Mode Detection
 
 Pick the mode from the tools available to you:
 
-- **A `deployComposeApp` tool is available (Goldsky webapp chatbot) — this is the preferred in-app flow.** Do NOT emit `goldsky` terminal commands or `cliCommand` cards, and do NOT use Step 0 / `degit` / `forge` / `goldsky compose deploy`. Instead: give a 2-3 sentence plain explanation, then ask the config questions one at a time with `askUser` (tag the recommended option with `recommendedIndex`):
-  1. **App name** (recommend `bitcoin-oracle`).
-  2. **Contract** — ask this explicitly, do not assume: *"Do you have your own `PriceOracle` contract, or should we use a shared demo oracle on Base Sepolia to get running quickly?"* Options: **"Use the shared demo oracle on Base Sepolia (recommended — nothing to deploy)"** and **"I'll use my own contract."** On the shared path, `ORACLE_CONTRACT` is the **HARDCODED** address `0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113` on `baseSepolia` — copy it character-for-character, do NOT alter or retype it from memory; mention in prose that it's demos-only, not production. On the own path, ask the user to paste their contract address and chain, and use exactly what they paste (their `PriceOracle` must let the Compose wallet write).
-  3. **Update frequency** (recommend every minute, `* * * * *`).
+- **A `deployComposeApp` tool is available (Goldsky webapp chatbot) — this is the preferred in-app flow.** Do NOT emit `goldsky` terminal commands or `cliCommand` cards, and do NOT use Step 0 / `degit` / `forge` / `goldsky compose deploy`. **Do NOT ask the user what to name the app** — name it `bitcoin-oracle` automatically; they can rename it after deploy. Give a 2-3 sentence plain explanation, then ask with `askUser` (tag the recommended option with `recommendedIndex`):
+  1. **Contract** — ask this explicitly, do not assume: *"Do you have your own `PriceOracle` contract, or should we use a shared demo oracle on Base Sepolia to get running quickly?"* Options: **"Use the shared demo oracle on Base Sepolia (recommended — nothing to deploy)"** and **"I'll use my own contract."** On the shared path, `ORACLE_CONTRACT` is the **HARDCODED** address `0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113` on `baseSepolia` — copy it character-for-character; mention in prose it's demos-only, not production. On the own path, ask the user to paste their contract address and chain and use exactly what they paste (their `PriceOracle` must let the Compose wallet write).
+  2. **Update frequency** (recommend every minute, `* * * * *`).
 
-  The Compose smart wallet is auto-created at runtime and gas-sponsored — never tell the user to create or fund a wallet. After the interview, scaffold the files in-memory and pass them to `deployComposeApp` (do NOT degit): `compose.yaml` (a single cron task on the chosen schedule), `src/contracts/PriceOracle.json` (the verbatim ABI in Step 3), and `src/tasks/bitcoin-oracle.ts` (fetch BTC/USD from CoinGecko, then `evm.contracts.PriceOracle.write(toBytes32(timestamp), toBytes32(Math.round(price*100)))` on the chosen chain via the gas-sponsored smart wallet, wired to `ORACLE_CONTRACT`, appending each price to a `bitcoin_prices` collection). **First load `/compose-reference`** for the manifest schema and the sandbox import rule, then write these files following them — do not invent the manifest shape or import external packages (`evm`/`fetch`/`collection` come from the injected `context`; the only imports allowed are `compose` and sibling files). Then **call `deployComposeApp` in the SAME turn to present the in-app deploy card** — do not ask the user to confirm first, do not emit any `goldsky` command, and do not make them run anything in a terminal. After the deploy card, print nothing else. **In this mode, ignore Steps 0–8 below entirely** — they are the CLI/local procedure.
-- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parse output, and substitute captured values into later commands.
-- **Neither (pure reference Q&A):** explain what the app does; only if asked for step-by-step help, output one command at a time and have the user paste output back. Point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
+  The Compose smart wallet is auto-created at runtime and gas-sponsored — never tell the user to create or fund a wallet. After the questions, scaffold the files in-memory (do NOT degit): `compose.yaml` (a single cron task on the chosen schedule), `src/contracts/PriceOracle.json` (the verbatim ABI in Step 3), and `src/tasks/bitcoin-oracle.ts` (fetch BTC/USD from CoinGecko, then `evm.contracts.PriceOracle.write(toBytes32(timestamp), toBytes32(Math.round(price*100)))` via the gas-sponsored smart wallet, appending each price to a `bitcoin_prices` collection). `ORACLE_CONTRACT` is a **hardcoded `const` at the top of the task file, not an env var** — do not put it under the manifest `env:` key. Follow `/compose-reference` for the manifest shape and the sandbox import rule before emitting the files (per the golden rules in `/compose` — don't synthesize the manifest from memory). Then **call `deployComposeApp` in the SAME turn**; don't ask the user to confirm first or emit any `goldsky` command. **In this mode, ignore Steps 0–8 below** — they are the CLI/local procedure.
+- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parsing output into later commands.
+- **Neither (pure reference Q&A):** explain what the app does; for step-by-step help point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
 
 ## Non-negotiables
 
@@ -29,10 +28,6 @@ Pick the mode from the tools available to you:
 - **Deploy-your-own path only:** the contract's authorized writer must be the Compose wallet, or every `write()` reverts. On the shared-oracle path there is no writer restriction, so this does not apply.
 - **The example ships only `src/contracts/PriceOracle.json` (the ABI), not Solidity source.** If deploying fresh, use the reference contract in this skill. Write the ABI verbatim — see Step 3.
 - **Do not touch `src/lib/utils.ts`.** `toBytes32` is coupled to how the contract stores the value.
-
-## Variable handling for agents
-
-When this skill says `$FOO`, capture the literal value from the prior command's output and substitute it directly into the next command. Do not rely on shell variables persisting between separate Bash tool invocations — each invocation gets a fresh shell with no env carryover from earlier commands.
 
 > **Steps 0–8 below are the Bash / local-CLI procedure. If a `deployComposeApp` tool is available (webapp chatbot), do NOT follow them — use the deploy-tool flow in Mode Detection above.**
 
@@ -56,21 +51,17 @@ If the user already cloned the example, skip this step and `cd` into it.
 
 ## Preflight
 
-1. **`goldsky` CLI** — `goldsky --version`. Install per https://docs.goldsky.com/reference/cli.
-2. **`goldsky` authenticated** — `goldsky project list`. If it errors, stop and tell the user: "Please run `goldsky login` in your terminal — browser flow. Tell me to continue when you see the success message." Do not spawn `goldsky login` from Bash; it requires an interactive browser.
-3. **`deno`** — `deno --version`. `curl -fsSL https://deno.land/install.sh | sh` if missing.
-4. **`foundry`** — `forge --version`. Only needed on the deploy-your-own path.
+The `goldsky` CLI, auth, and `deno` checks are the standard Compose preflight — see `/compose` and `/auth-setup`. Bitcoin-oracle-specific: **`foundry`** (`forge --version`) is needed only on the deploy-your-own path (Step 3, Branch B).
 
-## Step 1 — Configuration interview
+## Step 1 — Configuration
 
-Ask one question at a time; let each answer inform the next. Use readable labels and translate to machine values yourself.
+Name the app `bitcoin-oracle` (don't ask). Then, per the golden rules in `/compose`, ask only what you can't derive:
 
-1. **"App name?"** (recommend `bitcoin-oracle`) → top-level `name:` in `compose.yaml`.
-2. **"Which chain?"** — **Base Sepolia (recommended)** because it has the ready, fully-unpermissioned shared oracle (nothing to deploy). Other options (Base, Arbitrum, Polygon Amoy, etc.) require deploying your own oracle. Use the camelCase form in TS (`baseSepolia`).
-3. **"PriceOracle contract?"** (ask immediately after the chain) — two options:
+1. **"Which chain?"** — **Base Sepolia (recommended)** because it has the ready, fully-unpermissioned shared oracle (nothing to deploy). Other options (Base, Arbitrum, Polygon Amoy, etc.) require deploying your own oracle. Use the camelCase form in TS (`baseSepolia`).
+2. **"PriceOracle contract?"** (ask immediately after the chain) — two options:
    - **Reuse the shared oracle on Base Sepolia (recommended)** — nothing to deploy. Wire `0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113` (mention the address in prose, not in any option label). Demos/getting-started only, not production.
    - **Deploy my own** — see Step 3, Branch B. (Required on any chain other than Base Sepolia.)
-4. **"How often should the cron run?"** — Every minute (recommended, `* * * * *`), every 5 minutes (`*/5 * * * *`), or every hour. Set the `expression:` under the `cron` trigger in `compose.yaml`.
+3. **"How often should the cron run?"** — Every minute (recommended, `* * * * *`), every 5 minutes (`*/5 * * * *`), or every hour. Set the `expression:` under the `cron` trigger in `compose.yaml`.
 
 ## Step 2 — Wallet
 

--- a/skills/compose-bitcoin-oracle/SKILL.md
+++ b/skills/compose-bitcoin-oracle/SKILL.md
@@ -7,7 +7,16 @@ description: "Build and deploy the Goldsky Compose bitcoin-oracle example under 
 
 Stand up the bitcoin-oracle example under the user's own Goldsky account. A cron task fetches BTC/USD from CoinGecko and writes `(timestamp, price * 100)` as two `bytes32` values to a `PriceOracle` contract via a Compose-managed wallet. It also appends the price to a Compose `collection` for historical queries.
 
-This template supplies only what's specific to the bitcoin-oracle app — how it works and its source. It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes — consult before writing any `compose.yaml` or task) govern this build and are not repeated here. The recommended path uses a **shared, fully-unpermissioned `PriceOracle` on Base Sepolia**, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
+This template supplies only what's specific to the bitcoin-oracle app — how it works and its source. The recommended path uses a **shared, fully-unpermissioned `PriceOracle` on Base Sepolia**, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
+
+## Step 0 — Load the base skills first
+
+**Before anything else — before you answer, ask a question, scaffold a file, or call `deployComposeApp` — load the two base skills this template depends on:**
+
+1. **`Skill(compose)`** — the always-on Compose guide: the golden rules (never assume anything about the app on the user's behalf; ask when unsure) and general build guidance.
+2. **`Skill(compose-reference)`** — the manifest / field / API reference; consult before writing any `compose.yaml` or task file.
+
+This template deliberately omits those rules and that reference — they are **required** to build correctly and are not repeated here. Do not proceed until both are loaded.
 
 ## Mode Detection
 

--- a/skills/compose-dividend-distribution/SKILL.md
+++ b/skills/compose-dividend-distribution/SKILL.md
@@ -9,7 +9,16 @@ Stand up the corporate-actions distributor under the user's own Goldsky account.
 
 One HTTP task (`declare_campaign`) drives the whole lifecycle: declare → escrow USDC → spawn snapshot pipeline → poll → compute pro-rata → pay up to 25 holders concurrently → verify `escrowRemaining == 0` → delete the pipeline. Re-POSTing the same `campaignId` resumes cleanly after any failure; the contract is the sole source of truth for "did this holder get paid?", so double-pays are structurally impossible.
 
-This template supplies only what's specific to the dividend/corporate-actions app — how it works and its source. It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes) govern this build and are not repeated here. The recommended path uses **shared, permissionless demo contracts on Base Sepolia** (open `mint` on MockUSDC, open `declare()` on the campaign), so there's nothing to deploy.
+This template supplies only what's specific to the dividend/corporate-actions app — how it works and its source. The recommended path uses **shared, permissionless demo contracts on Base Sepolia** (open `mint` on MockUSDC, open `declare()` on the campaign), so there's nothing to deploy.
+
+## Step 0 — Load the base skills first
+
+**Before anything else — before you answer, ask a question, scaffold a file, or run any command — load the two base skills this template depends on:**
+
+1. **`Skill(compose)`** — the always-on Compose guide: the golden rules (never assume anything about the app on the user's behalf; ask when unsure) and general build guidance.
+2. **`Skill(compose-reference)`** — the manifest / field / API reference; consult before writing any `compose.yaml` or task file.
+
+This template deliberately omits those rules and that reference — they are **required** to build correctly and are not repeated here. Do not proceed until both are loaded.
 
 ## Mode Detection
 

--- a/skills/compose-dividend-distribution/SKILL.md
+++ b/skills/compose-dividend-distribution/SKILL.md
@@ -9,7 +9,7 @@ Stand up the corporate-actions distributor under the user's own Goldsky account.
 
 One HTTP task (`declare_campaign`) drives the whole lifecycle: declare → escrow USDC → spawn snapshot pipeline → poll → compute pro-rata → pay up to 25 holders concurrently → verify `escrowRemaining == 0` → delete the pipeline. Re-POSTing the same `campaignId` resumes cleanly after any failure; the contract is the sole source of truth for "did this holder get paid?", so double-pays are structurally impossible.
 
-The recommended path uses **shared, permissionless demo contracts on Base Sepolia** (open `mint` on MockUSDC, open `declare()` on the campaign), so there's nothing to deploy. Assume the user has never used Goldsky Compose before. Do not skip preflight.
+This template supplies only what's specific to the dividend/corporate-actions app — how it works and its source. It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes) govern this build and are not repeated here. The recommended path uses **shared, permissionless demo contracts on Base Sepolia** (open `mint` on MockUSDC, open `declare()` on the campaign), so there's nothing to deploy.
 
 ## Mode Detection
 
@@ -28,10 +28,6 @@ Pick the mode from the tools available to you:
 - **The deployer `PRIVATE_KEY` (deploy-your-own path only) is a real EOA key.** Do not print it, commit it, or log it; pass it only as an env var to `scripts/deploy.sh`.
 - **Resumable by design — never worry about double-pay.** Re-POSTing the same `campaignId` drives the existing campaign forward. A per-holder on-chain `isPaid()` check plus the contract's `require(!paid[id][holder])` guard mean Compose can crash/restart at any point with zero risk of double-paying.
 - **This example does not run in a local/dev Compose cluster without Turbo pipeline infra.** It deploys against real Goldsky (app.goldsky.com), which is where a user runs it anyway.
-
-## Variable handling for agents
-
-When this skill says `$FOO`, capture the literal value from the prior command's output and substitute it directly into the next command. Do not rely on shell variables persisting between separate Bash tool invocations — each invocation gets a fresh shell with no env carryover from earlier commands.
 
 ## The manifest and demo config
 
@@ -102,11 +98,11 @@ If the user already cloned the example, skip this and `cd` into it.
 
 ## Preflight
 
-1. **`goldsky` CLI** — `goldsky --version`. Install per https://docs.goldsky.com/reference/cli.
-2. **`goldsky` authenticated** — `goldsky project list`. If it errors, stop and tell the user: "Please run `goldsky login` in your terminal — browser flow. Tell me to continue when you see the success message." Do not spawn `goldsky login` from Bash; it requires an interactive browser.
-3. **Project API key** — the user needs a Compose/project API key from the Goldsky dashboard (https://app.goldsky.com). It's used both as the `-t` deploy token and as the `GOLDSKY_PROJECT_KEY` secret. Ask them to have it ready; do not print it back.
-4. **`node` + `npm`** — `npm --version`, then `npm install` (the app bundles `viem`).
-5. **`foundry`** — `cast --version` / `forge --version`. Needed only on the deploy-your-own path (Step 1, Branch B) and for minting/verifying via `cast`.
+The `goldsky` CLI and auth checks are the standard Compose preflight — see `/compose` and `/auth-setup`. Dividend-specific:
+
+1. **Project API key** — the user needs a Compose/project API key from the Goldsky dashboard (https://app.goldsky.com). It's used both as the `-t` deploy token and as the `GOLDSKY_PROJECT_KEY` secret. Ask them to have it ready; do not print it back.
+2. **`node` + `npm`** — `npm --version`, then `npm install` (the app bundles `viem`).
+3. **`foundry`** — `cast --version` / `forge --version`. Needed only on the deploy-your-own path (Step 1, Branch B) and for minting/verifying via `cast`.
 
 ## Step 1 — Contracts
 

--- a/skills/compose-dividend-distribution/SKILL.md
+++ b/skills/compose-dividend-distribution/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: compose-dividend-distribution
+description: "Build and deploy the Goldsky Compose corporate-actions / dividend-distribution example under the user's own account — a durable, idempotent distributor that pays N token holders pro-rata for a tokenized corporate action (dividend, coupon, rebate, airdrop) with an on-chain audit trail. The interesting bit: Compose orchestrates a Goldsky Turbo job-mode pipeline as an ephemeral subroutine — declaring a campaign spawns a one-shot pipeline that snapshots share-token holders at a record block, waits for it, pays each holder via a gas-sponsored wallet, then deletes the pipeline. Triggers on: 'dividend distribution', 'pay dividends onchain', 'distribute dividends to shareholders', 'corporate actions distributor', 'pro-rata payout to token holders', 'airdrop pro-rata by balance', 'cap table distribution', 'set up / deploy the dividend / corporate-actions example'. Ships pointed at shared permissionless demo contracts on Base Sepolia so there's nothing to deploy. NOTE: this example is CLI-driven — it needs a project-API-key secret and spawns Turbo pipelines at runtime, so it cannot be deployed through the in-app deployComposeApp card. For a custom/novel Compose app, use /compose. For debugging a deployed app, use /compose-doctor. For manifest/CLI/API field lookups, use /compose-reference."
+---
+
+# Build: Compose dividend distribution (corporate-actions)
+
+Stand up the corporate-actions distributor under the user's own Goldsky account. It pays N holders pro-rata for a tokenized corporate action — dividend, coupon, rebate, airdrop — idempotently and durably, with a tamper-evident on-chain audit trail. The interesting bit: **Compose orchestrates Goldsky Turbo as an ephemeral, on-demand subroutine.** Declaring a campaign spawns a one-shot [job-mode](https://docs.goldsky.com/turbo-pipelines/job-mode) Turbo pipeline that snapshots share-token holders at the operator-supplied record block; Compose waits for it to finish, pays each holder via a gas-sponsored wallet, then deletes the pipeline. No always-on indexing.
+
+One HTTP task (`declare_campaign`) drives the whole lifecycle: declare → escrow USDC → spawn snapshot pipeline → poll → compute pro-rata → pay up to 25 holders concurrently → verify `escrowRemaining == 0` → delete the pipeline. Re-POSTing the same `campaignId` resumes cleanly after any failure; the contract is the sole source of truth for "did this holder get paid?", so double-pays are structurally impossible.
+
+The recommended path uses **shared, permissionless demo contracts on Base Sepolia** (open `mint` on MockUSDC, open `declare()` on the campaign), so there's nothing to deploy. Assume the user has never used Goldsky Compose before. Do not skip preflight.
+
+## Mode Detection
+
+Pick the mode from the tools available to you:
+
+- **A `deployComposeApp` tool is available (Goldsky webapp chatbot).** This example **cannot be deployed through the in-app deploy card**, and that is expected — say so plainly. Two hard reasons: (1) it requires a project-API-key secret (`GOLDSKY_PROJECT_KEY`) that only the `goldsky` CLI / dashboard can set, and (2) at runtime it spawns, polls, and deletes **job-mode Turbo pipelines**, which the in-app single-app deploy path does not provision. So do NOT scaffold files or call `deployComposeApp`. Instead: give a 3-4 sentence explanation of what the app does and why it's CLI-driven, then walk the user through the CLI steps below (or tell them to run this skill locally with `npx skills add goldsky-io/goldsky-agent` where a `Bash` tool is available). Everything from Step 0 down is that CLI procedure.
+- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parse output, and substitute captured values into later commands.
+- **Neither (pure reference Q&A):** explain what the app does and the lifecycle; only if asked for step-by-step help, output one command at a time and have the user paste output back. Point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
+
+## Non-negotiables
+
+- **Ships pointed at shared, permissionless demo contracts on Base Sepolia — nothing to deploy.** MockUSDC has an open `mint` and DistributionCampaign has an open `declare()`, so anyone can run a campaign on them. Addresses live in `src/lib/constants.ts` (see below). Tell the user, in prose, these are demos/getting-started only, not production, and only exist on Base Sepolia.
+- **This app needs a project API key in two places:** the `-t <key>` flag on `goldsky compose deploy` (to deploy), **and** a `GOLDSKY_PROJECT_KEY` secret (so the running app can spawn / poll / delete Turbo pipelines). It won't run without the secret. They can be the same key.
+- **`recordBlock` must be `<= currentBlock`** and should be past finality (e.g. `currentBlock - 32`). The snapshot is backwards-looking — it's the cutoff for who gets paid. Future-dated record blocks are out of scope.
+- **Never run `forge create` (deploy-your-own), `goldsky compose deploy`, `goldsky secret create`, `git push`, or `gh repo create` without showing the exact command first and getting explicit confirmation.**
+- **The deployer `PRIVATE_KEY` (deploy-your-own path only) is a real EOA key.** Do not print it, commit it, or log it; pass it only as an env var to `scripts/deploy.sh`.
+- **Resumable by design — never worry about double-pay.** Re-POSTing the same `campaignId` drives the existing campaign forward. A per-holder on-chain `isPaid()` check plus the contract's `require(!paid[id][holder])` guard mean Compose can crash/restart at any point with zero risk of double-paying.
+- **This example does not run in a local/dev Compose cluster without Turbo pipeline infra.** It deploys against real Goldsky (app.goldsky.com), which is where a user runs it anyway.
+
+## Variable handling for agents
+
+When this skill says `$FOO`, capture the literal value from the prior command's output and substitute it directly into the next command. Do not rely on shell variables persisting between separate Bash tool invocations — each invocation gets a fresh shell with no env carryover from earlier commands.
+
+## The manifest and demo config
+
+The app itself is a single HTTP task plus a small TypeScript library and three Solidity contracts. It is large enough that the CLI flow **scaffolds it from `goldsky-io/documentation-examples` via `degit` (Step 0)** rather than writing every file by hand — only edit files when customizing. The two pieces worth seeing inline:
+
+### `compose.yaml`
+
+```yaml
+name: "corporate-actions"
+api_version: "stable"
+
+# POSTGRES_CONNECTION_STRING is auto-injected at deploy time by compose-cloud.
+# A Goldsky-project secret named CORPORATE_ACTIONS is created alongside it,
+# referencing the same Neon DB. The job-mode Turbo pipelines that
+# declare_campaign spawns (see src/lib/turbo.ts) write share-balance
+# snapshots back into that DB.
+secrets:
+  # Project API key used to spawn / poll / delete Turbo pipelines from
+  # inside declare_campaign. Set once: goldsky secret create GOLDSKY_PROJECT_KEY <key>
+  - GOLDSKY_PROJECT_KEY
+
+tasks:
+  - path: "./src/tasks/declare-campaign.ts"
+    name: "declare_campaign"
+    triggers:
+      - type: "http"
+        authentication: "auth_token"
+    retry_config:
+      max_attempts: 1
+      initial_interval_ms: 500
+      backoff_factor: 1
+```
+
+### Shared demo contracts — `src/lib/constants.ts` (`CONFIG`)
+
+The repo ships pointed at these permissionless Base Sepolia contracts. On the no-deploy path, leave them as-is:
+
+```ts
+export const CONFIG = {
+  chain:      "baseSepolia" as const,   // evm.chains[chain] key (camelCase)
+  turboChain: "base_sepolia",           // Turbo dataset prefix (snake_case)
+  shareToken:       "0x713e0749a9Fe480322990913850e81b0F4F4dc0d", // 25 seed holders pre-minted
+  payToken:         "0x8ec24F07F08745fc3D979336AA81d4Dc73f3D9DE", // MockUSDC (permissionless mint)
+  campaignContract: "0xA8e58573B1e10908b63d12B603aCF9C784BF904E", // permissionless: anyone can declare()
+  shareTokenDeployBlock: 42275958,      // lower bound for the snapshot pipeline's block-range filter
+};
+```
+
+Deploy-your-own (Step 1, Branch B) replaces these four values with the addresses `scripts/deploy.sh` prints. The rest of the app (`src/lib/{types,normalize,math,db,turbo,driver}.ts`, `src/tasks/declare-campaign.ts`, `contracts/*.sol`) is scaffolded verbatim by `degit`; read those files in the cloned repo if the user wants to customize the payout math, the concurrency, or the pipeline shape.
+
+## Step 0 — Scaffold the example
+
+Pull just the corporate-actions example into a fresh directory (no git history):
+
+```bash
+npx degit goldsky-io/documentation-examples/compose/corporate-actions dividend-distribution
+cd dividend-distribution
+```
+
+If `npx degit` is unavailable, fall back to a sparse clone:
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/goldsky-io/documentation-examples.git
+cd documentation-examples && git sparse-checkout set compose/corporate-actions && cd compose/corporate-actions
+```
+
+If the user already cloned the example, skip this and `cd` into it.
+
+## Preflight
+
+1. **`goldsky` CLI** — `goldsky --version`. Install per https://docs.goldsky.com/reference/cli.
+2. **`goldsky` authenticated** — `goldsky project list`. If it errors, stop and tell the user: "Please run `goldsky login` in your terminal — browser flow. Tell me to continue when you see the success message." Do not spawn `goldsky login` from Bash; it requires an interactive browser.
+3. **Project API key** — the user needs a Compose/project API key from the Goldsky dashboard (https://app.goldsky.com). It's used both as the `-t` deploy token and as the `GOLDSKY_PROJECT_KEY` secret. Ask them to have it ready; do not print it back.
+4. **`node` + `npm`** — `npm --version`, then `npm install` (the app bundles `viem`).
+5. **`foundry`** — `cast --version` / `forge --version`. Needed only on the deploy-your-own path (Step 1, Branch B) and for minting/verifying via `cast`.
+
+## Step 1 — Contracts
+
+**Branch A — Reuse the shared demo contracts (recommended).** Nothing to deploy. Leave `CONFIG` in `src/lib/constants.ts` at the shared Base Sepolia addresses shown above. Skip to Step 2.
+
+**Branch B — Deploy your own.** Output this for the user to run with their own funded Base Sepolia EOA (~0.0005 ETH). It deploys MockUSDC + ShareToken (pre-minting to the 25 addresses in `scripts/seed-holders.json`) + DistributionCampaign:
+
+```bash
+PRIVATE_KEY=0x... ./scripts/deploy.sh
+```
+
+It prints the three addresses and the ShareToken deploy block. Copy them into `CONFIG` in `src/lib/constants.ts` (`payToken`, `shareToken`, `campaignContract`, `shareTokenDeployBlock`). To run on Base mainnet instead, see the comment in `constants.ts` and set `chain`/`turboChain` to `base`.
+
+## Step 2 — Set the project-key secret
+
+The running app uses this to spawn / poll / delete Turbo pipelines:
+
+```bash
+goldsky secret create GOLDSKY_PROJECT_KEY <your project API key>
+```
+
+## Step 3 — Deploy the Compose app
+
+```bash
+goldsky compose deploy -t <your project API key>
+```
+
+Compose-cloud auto-provisions a hosted Neon Postgres DB and creates a project secret named `CORPORATE_ACTIONS` pointing at it; the job-mode pipelines write snapshots into that DB. First deploy may take 1-2 minutes. Watch for `Deployed compose app: corporate-actions` and the HTTP task URL.
+
+## Step 4 — Mint MockUSDC to the operator
+
+The operator wallet address is printed in the app's logs on the first request (`goldsky compose logs`). On the shared demo, MockUSDC's `mint` is open, so anyone can fund it. Mint generously for many campaigns (1,000,000 mUSDC = `1000000000000`, 6 decimals):
+
+```bash
+cast send 0x8ec24F07F08745fc3D979336AA81d4Dc73f3D9DE "mint(address,uint256)" <OPERATOR> 1000000000000 \
+  --rpc-url https://sepolia.base.org --private-key $PRIVATE_KEY
+```
+
+(On the deploy-your-own path, use your MockUSDC address instead.)
+
+## Step 5 — Declare a campaign
+
+Pick a record block past finality, then POST. `$GOLDSKY_TOKEN` is a Compose API token (bearer) for the HTTP task:
+
+```bash
+RECORD_BLOCK=$(cast block-number --rpc-url https://sepolia.base.org)
+RECORD_BLOCK=$((RECORD_BLOCK - 32))
+
+curl -sX POST "https://api.goldsky.com/api/admin/compose/v1/corporate-actions/tasks/declare_campaign" \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer $GOLDSKY_TOKEN" \
+  -d "{
+    \"campaignId\":  \"0x000000000000000000000000000000000000000000000000000000000000c0a1\",
+    \"recordBlock\": $RECORD_BLOCK,
+    \"totalAmount\": \"10000000000\"
+  }"
+```
+
+That declares a 10,000 mUSDC distribution. The request stays open ~10-30s while Compose snapshots holders, computes pro-rata, and fires the 25 `pay()` calls in one batch. The response body includes the final campaign state (`complete` on the happy path, or `paying` if it needs another drive call — just re-POST the same `campaignId`).
+
+## Step 6 — Verify on-chain
+
+```bash
+cast call 0xA8e58573B1e10908b63d12B603aCF9C784BF904E "getCampaign(bytes32)" <onChainId> \
+  --rpc-url https://sepolia.base.org
+```
+
+`escrowRemaining` is exactly `0` once all 25 holders are paid. The full audit trail is the contract's `HolderPaid` events.
+
+## Troubleshooting
+
+- **Edits to `compose.yaml` or source files don't take effect after redeploy.** The local `.compose/` bundle cache is stale. Run `rm -rf .compose/` and redeploy.
+- **App errors spawning the pipeline / `401` or `403` from the pipelines API.** The `GOLDSKY_PROJECT_KEY` secret is missing or wrong. Re-create it (Step 2) with a valid project API key and redeploy.
+- **Snapshot never completes / campaign stuck in `snapshotting`.** Confirm `recordBlock <= currentBlock` and `>= shareTokenDeployBlock`, and that `CONFIG.shareToken` / `shareTokenDeployBlock` match the token you're distributing over. The pipeline filters `block_number BETWEEN <deployBlock> AND <recordBlock>`.
+- **`declare()` reverts.** On the shared contract, ensure the operator approved and holds enough MockUSDC for `totalAmount` (mint more in Step 4). On your own contract, confirm the campaign contract points at the right pay token.
+- **Campaign returns `paying` (not `complete`).** Some `pay()` calls didn't land this drive. Re-POST the same `campaignId` — already-paid holders are skipped via on-chain `isPaid()`, and the run resumes.
+- **No hosted DB / snapshot rows.** Confirm the deploy created the `CORPORATE_ACTIONS` secret (compose-cloud does this automatically); if not, redeploy with `-t <key>`.
+
+## What you should NOT do
+
+- Do not use the shared Base Sepolia contracts as a production target — they're permissionless (anyone can mint mUSDC or declare a campaign).
+- Do not deploy this to a local/dev Compose cluster that lacks Turbo pipeline infra — the snapshot step will hang. Deploy against real Goldsky.
+- Do not put the `GOLDSKY_PROJECT_KEY` on a command line where it lands in shell history beyond the `secret create` call; do not commit it.
+- Do not lower the `recordBlock` below `shareTokenDeployBlock`, and do not use a future block — the snapshot is backwards-looking by definition.
+- Do not hand-edit the per-campaign pipeline/table names in `src/lib/constants.ts` (`pipelineName` / `aggTableName`) — they're derived from `campaignId` and must stay stable for resume to work.
+
+## Related
+
+- **`/compose`** — Build a new/custom Compose app from scratch, or explain what Compose is.
+- **`/compose-reference`** — Manifest, CLI, TaskContext API, wallets, gas sponsorship, codegen.
+- **`/compose-doctor`** — Diagnose and fix a broken Compose app.
+- **`/turbo-pipelines`** / **`/turbo-operations`** — Job-mode pipeline shape and lifecycle, if customizing the snapshot.
+- **`/auth-setup`** — `goldsky login` walkthrough.

--- a/skills/compose-vrf/SKILL.md
+++ b/skills/compose-vrf/SKILL.md
@@ -7,7 +7,7 @@ description: "Build and deploy the Goldsky Compose VRF (verifiable random functi
 
 Stand up the VRF example under the user's own Goldsky account. The app listens for a `RandomnessRequested(uint256,address)` event on an EVM contract, fetches verifiable randomness from the **drand** beacon (BLS12-381 threshold signatures, verifiable by anyone), and writes it back on-chain via `fulfillRandomness(requestId, randomness, round, signature)`. Trust comes from the stored drand `round` + `signature`, not from the caller, so the shared example contract is safe to leave open.
 
-This skill is the single source of truth for the procedure and carries the **full app source below** (manifest, contract, ABI, both trigger tasks, and the drand helper). The recommended path uses a **shared, fully-unpermissioned `RandomnessConsumer` on Base Sepolia** at `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d`, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored. Assume the user has never used Goldsky Compose before. Do not skip preflight.
+This template supplies only what's specific to the VRF app — how it works and its **full source** (below). It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes — consult before writing any `compose.yaml` or task) govern this build and are not repeated here. The recommended path uses a **shared, fully-unpermissioned `RandomnessConsumer` on Base Sepolia** at `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d`, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
 
 ## Mode Detection
 
@@ -16,9 +16,9 @@ Pick the mode from the tools available to you:
 - **A `deployComposeApp` tool is available (Goldsky webapp chatbot) — this is the preferred in-app flow.** Do NOT emit `goldsky` terminal commands or `cliCommand` cards, and do NOT use Step 0 / `degit` / `forge` / `goldsky compose deploy`. Instead: give a 2-3 sentence plain explanation, then ask the **single** config question below with `askUser` (tag the recommended option with `recommendedIndex`). **Do NOT ask the user what to name the app** — name it `vrf-app` automatically; they can rename it after it's deployed. Ask only:
   - **Contract** — ask this explicitly, do not assume: *"Do you have your own `RandomnessConsumer`-style contract, or should we use a shared demo contract on Base Sepolia to get running quickly?"* Options: **"Use the shared demo contract on Base Sepolia (recommended — nothing to deploy)"** and **"I'll use my own contract."** On the shared path, `CONTRACT_ADDRESS` is the **HARDCODED** address `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d` on `baseSepolia` — copy it character-for-character, do NOT alter or retype it from memory; mention in prose that it's demos-only, not production. On the own path, ask the user to paste their contract address and chain (their contract must emit `RandomnessRequested(uint256,address)` and accept `fulfillRandomness`), and use exactly what they paste.
 
-  The Compose smart wallet is auto-created at runtime and gas-sponsored on Base Sepolia — never tell the user to create or fund a wallet. On the shared path there is **no fulfiller to set** (the contract is permissionless), so the wallet just works. After the single question, scaffold the files in-memory from **The app (full source)** below and pass them to `deployComposeApp` (do NOT degit): `compose.yaml`, `src/contracts/RandomnessConsumer.json` (the verbatim ABI, required for contract codegen), `src/lib/drand.ts`, `src/tasks/fulfill-randomness.ts`, `src/tasks/request-randomness.ts`, and `src/tasks/generate-wallet.ts`. Set the top-level `name:` in `compose.yaml` to `vrf-app`. Set `CONTRACT_ADDRESS` in both task files and the `contract:` field in `compose.yaml` to the shared address (or the user's, on the own path); set the `evm.chains.*` reference and the trigger `network:` to the chosen chain. **First load `/compose-reference`** for the manifest schema and the sandbox import rule, then emit the files following them — do not invent the manifest shape. The tasks import only from `compose` and the sibling `../lib/drand.ts`; `evm` and `fetch` come from the injected `context`, never from npm. Then **call `deployComposeApp` in the SAME turn to present the in-app deploy card** — do not ask the user to confirm first, do not emit any `goldsky` command, and do not make them run anything in a terminal. After the deploy card, print nothing else. **In this mode, ignore Steps 0–8 below entirely** — they are the CLI/local procedure.
-- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parse output, and substitute captured values into later commands.
-- **Neither (pure reference Q&A):** explain what the app does; only if asked for step-by-step help, output one command at a time and have the user paste output back. Point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
+  The Compose smart wallet is auto-created at runtime and gas-sponsored on Base Sepolia — never tell the user to create or fund a wallet. On the shared path there is **no fulfiller to set** (the contract is permissionless), so the wallet just works. After the single question, scaffold these files in-memory from **The app (full source)** below and pass them to `deployComposeApp` (do NOT degit): `compose.yaml`, `src/contracts/RandomnessConsumer.json` (verbatim ABI, required for codegen), `src/lib/drand.ts`, and the three task files. Set the top-level `name:` to `vrf-app`; set `CONTRACT_ADDRESS` in both task files and the `contract:` field in `compose.yaml` to the shared address (or the user's, on the own path), and the `evm.chains.*` reference + trigger `network:` to the chosen chain. Follow `/compose-reference` for the manifest shape and the sandbox import rule before emitting the files (per the golden rules in `/compose` — don't synthesize the manifest from memory). Then **call `deployComposeApp` in the SAME turn**; don't ask the user to confirm first or emit any `goldsky` command. **In this mode, ignore Steps 0–8 below** — they are the CLI/local procedure.
+- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parsing output into later commands.
+- **Neither (pure reference Q&A):** explain what the app does; for step-by-step help point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
 
 ## Non-negotiables
 
@@ -27,10 +27,6 @@ Pick the mode from the tools available to you:
 - **Three places share the contract address:** the `contract:` field in `compose.yaml`, and `CONTRACT_ADDRESS` in both `src/tasks/fulfill-randomness.ts` and `src/tasks/request-randomness.ts`. If the user changes it, change all three.
 - **Deploy-your-own path only:** the drand fulfillment is permissionless in the reference contract, but if the user's own contract restricts fulfillment, the authorized fulfiller must be the Compose wallet or every `fulfillRandomness` reverts. On the shared contract there is no such restriction.
 - **Never run `forge create`, `goldsky compose deploy`, `git push`, or `gh repo create` without showing the exact command first and getting explicit confirmation.**
-
-## Variable handling for agents
-
-When this skill says `$FOO`, capture the literal value from the prior command's output and substitute it directly into the next command. Do not rely on shell variables persisting between separate Bash tool invocations — each invocation gets a fresh shell with no env carryover from earlier commands.
 
 ## The app (full source)
 
@@ -500,12 +496,7 @@ If the user already cloned the example, skip this step and `cd` into it. Either 
 
 ## Preflight
 
-Run these checks in order. Stop and resolve each before moving on.
-
-1. **`goldsky` CLI** — `goldsky --version`. Install per https://docs.goldsky.com/reference/cli.
-2. **`goldsky` authenticated** — `goldsky project list`. If it errors, stop and tell the user: "Please run `goldsky login` in your terminal — browser flow. Tell me to continue when you see the success message." Do not spawn `goldsky login` from Bash; it requires an interactive browser.
-3. **`deno`** — `deno --version`. `curl -fsSL https://deno.land/install.sh | sh` if missing.
-4. **`foundry`** — `forge --version`. Only needed on the deploy-your-own path.
+The `goldsky` CLI, auth, and `deno` checks are the standard Compose preflight — see `/compose` and `/auth-setup`. VRF-specific: **`foundry`** (`forge --version`) is needed only on the deploy-your-own path (Step 3, Branch B).
 
 ## Step 1 — Configuration interview
 

--- a/skills/compose-vrf/SKILL.md
+++ b/skills/compose-vrf/SKILL.md
@@ -7,7 +7,16 @@ description: "Build and deploy the Goldsky Compose VRF (verifiable random functi
 
 Stand up the VRF example under the user's own Goldsky account. The app listens for a `RandomnessRequested(uint256,address)` event on an EVM contract, fetches verifiable randomness from the **drand** beacon (BLS12-381 threshold signatures, verifiable by anyone), and writes it back on-chain via `fulfillRandomness(requestId, randomness, round, signature)`. Trust comes from the stored drand `round` + `signature`, not from the caller, so the shared example contract is safe to leave open.
 
-This template supplies only what's specific to the VRF app — how it works and its **full source** (below). It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes — consult before writing any `compose.yaml` or task) govern this build and are not repeated here. The recommended path uses a **shared, fully-unpermissioned `RandomnessConsumer` on Base Sepolia** at `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d`, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
+This template supplies only what's specific to the VRF app — how it works and its **full source** (below). The recommended path uses a **shared, fully-unpermissioned `RandomnessConsumer` on Base Sepolia** at `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d`, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
+
+## Step 0 — Load the base skills first
+
+**Before anything else — before you answer, ask a question, scaffold a file, or call `deployComposeApp` — load the two base skills this template depends on:**
+
+1. **`Skill(compose)`** — the always-on Compose guide: the golden rules (never assume anything about the app on the user's behalf; ask when unsure) and general build guidance.
+2. **`Skill(compose-reference)`** — the manifest / field / API reference; consult before writing any `compose.yaml` or task file.
+
+This template deliberately omits those rules and that reference — they are **required** to build correctly and are not repeated here. Do not proceed until both are loaded.
 
 ## Mode Detection
 

--- a/skills/compose/SKILL.md
+++ b/skills/compose/SKILL.md
@@ -7,6 +7,10 @@ description: "Always load this skill whenever the conversation is about Goldsky 
 
 Goldsky Compose is the offchain-to-onchain framework for high-stakes systems. Write TypeScript **tasks** that run in verifiable sandboxes — triggered by cron, HTTP, or onchain events — with smart wallets, gas sponsorship, and durable collections. Typical use cases: custom price oracles, keepers, circuit breakers, prediction-market resolvers, cross-chain automation, identity/attestation flows, and notifications.
 
+## Step 0 — Load the reference first
+
+**Before anything else — before you write any `compose.yaml` or task file, quote a field / flag / API shape, or scaffold or deploy an app — load `Skill(compose-reference)`.** It's the full manifest / CLI / `TaskContext` / wallet / gas-sponsorship reference. This skill gives the rules and the shape of a build; `compose-reference` gives the exact fields and signatures — and per the Golden rules below, the manifest / CLI / API must never be synthesized from memory. Do not emit a manifest or task without it loaded.
+
 ## Skill family — load `compose` first
 
 `compose` is the entry point for anything Goldsky Compose: **load it first, then pull in the others as needed.**

--- a/skills/compose/SKILL.md
+++ b/skills/compose/SKILL.md
@@ -20,6 +20,18 @@ Goldsky Compose is the offchain-to-onchain framework for high-stakes systems. Wr
 - **Any field, flag, manifest shape, or API signature** — load `/compose-reference`. It's the full reference docs. Consult it before writing any `compose.yaml` or task file.
 - **A broken app** — `/compose-doctor`.
 
+## Template catalog
+
+The worked-example templates are starting points for whole classes of app, not just their literal use case. Match a new app against this catalog by **scope and pattern**, not by name:
+
+| Template | Scope / pattern | Start here when the app is… |
+| --- | --- | --- |
+| `/compose-bitcoin-oracle` | cron → fetch offchain data → `writeContract` | a keeper or oracle that periodically pushes a value onchain |
+| `/compose-vrf` | `onchain_event` → fetch → write back with proof | event-driven request/response, verifiable callbacks |
+| `/compose-dividend-distribution` | CLI-driven; spawns a Turbo pipeline; gas-sponsored pro-rata payouts | batch payouts, snapshot-then-distribute, cap-table style |
+
+The survey against this catalog is a required build step — see **Step 3** below.
+
 ## Golden rules (all modes, including the in-app deploy card)
 
 - **Never assume anything about the app on the user's behalf.** Derive what you can from what the user actually said; for anything material to how the app is built or behaves that you cannot derive — contract address, chain, ABI, trigger cadence, wallet choice, secret values — **ask the user**. Do not invent it, guess it, or carry a value over from an example.
@@ -258,9 +270,16 @@ From the user's natural-language prompt, **derive** as many of these as possible
 
 Only ask the user for fields you couldn't derive.
 
-### Step 3 — Scaffold
+### Step 3 — Match against the worked examples, then scaffold
 
-`goldsky compose init <name>`. Inspect the scaffold to see the canonical file layout.
+**If a template skill is already loaded** (the user asked for that specific example), skip the survey and build from it.
+
+**Otherwise the survey is required before scaffolding.** Compare the derived trigger + behavior against the Template catalog above:
+
+- **A template matches in scope** → load it (`/compose-<name>`) and start from its source instead of a blank init.
+- **None match** → say so in one line, then `goldsky compose init <name>` and inspect the scaffold for the canonical file layout.
+
+Never build a custom app without doing this comparison first.
 
 ### Step 4 — Edit the manifest
 


### PR DESCRIPTION
Builds on the compose skill-family hierarchy (#44, now on main). Adds the dividend worked-example skill, aligns all three worked-example templates to the hierarchy, and hardens the "chain-load the base skills" behavior with front-loaded gates. (Supersedes #45.)

## New skill: `compose-dividend-distribution`

The corporate-actions distributor. One HTTP task orchestrates a Turbo job-mode pipeline to snapshot share-token holders at a record block, then pays each holder pro-rata onchain via a gas-sponsored wallet — crash-safe and resumable on `campaignId`. Ships pointed at shared permissionless demo contracts on Base Sepolia. CLI-driven (needs a `GOLDSKY_PROJECT_KEY` secret + spawns Turbo pipelines, so it can't go through the in-app deploy card). Registered in `SKILLS.md` / `README.md`.

## Aligned all three templates to the hierarchy

`compose-bitcoin-oracle`, `compose-vrf`, `compose-dividend-distribution` now:
- Defer the golden rules to `/compose` and manifest/field/API shapes to `/compose-reference` instead of repeating them.
- Drop the duplicated compose-reference/import-rule boilerplate, the generic CLI/auth/deno preflight (now in `/compose` + `/auth-setup`), and the generic variable-handling note.
- Stop asking the user to name the app (auto-name it; rename after deploy).
- Keep the app-specific description, **full source**, steps, and troubleshooting.
- bitcoin-oracle keeps a one-line "\`ORACLE_CONTRACT\` is a hardcoded const, not an \`env:\` key" note (the FOU-982 failure).

## Front-loaded Step 0 gates (so the chain-load actually happens)

A dependency mentioned in intro prose gets skimmed past — the model loads the template and builds without loading the base skills. So each skill now opens with a **blocking Step 0** before Mode Detection, phrased as imperative \`Skill(...)\` calls:
- Each template: *"Before anything else … load \`Skill(compose)\` then \`Skill(compose-reference)\`. Do not proceed until both are loaded."*
- \`/compose\` itself: *"Before anything else … load \`Skill(compose-reference)\`. Do not emit a manifest or task without it loaded."*

## Require surveying the templates before building a custom app

Previously the entry skill only pointed at a template when the user named that specific example, so whether an arbitrary-app build reused a template was luck. Now \`/compose\` carries a **Template catalog** table (each worked example mapped to its scope/pattern), and Step 3 is a required gate: unless a template skill is already loaded, the agent must compare the derived app against the catalog and start from the closest-in-scope match, only falling back to a blank \`init\` when none fit. This makes "look at our templates for inspiration first" reliable instead of incidental.

## Note

The \`/compose\` edits touch \`skills/compose/SKILL.md\` (owned by #44, already merged), so that one file rides on this PR too. Happy to split it into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)