### PR TITLE
Establish compose skill hierarchy and golden rules (FOU-982)

### DIFF
--- a/skills/compose-reference/SKILL.md
+++ b/skills/compose-reference/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: compose-reference
-description: "Use this skill when the user asks about a Goldsky Compose field, flag, type, or API shape — lookup reference for compose.yaml fields, every `goldsky compose` CLI flag, the TaskContext API (env, fetch, callTask, logEvent, evm, collection), wallet APIs (smart wallet, BYO EOA), gas sponsorship, contract codegen, dashboard URL, and pricing. Triggers on: 'compose.yaml fields', 'cron syntax for compose', 'http trigger auth', 'onchain_event format', 'TaskContext API', 'evm.wallet options', 'sponsorGas default', 'IWallet methods', 'Collection methods', 'compose codegen', 'compose pricing', 'compose status JSON output', 'goldsky compose flags'. Consult before suggesting a field, flag, or API shape — avoids hallucinating nonexistent options. For step-by-step building, use /compose. For debugging, use /compose-doctor. Do NOT trigger on Turbo, Mirror, Subgraphs, or Edge lookups — those belong to their own reference skills."
+description: "Load this skill whenever building, editing, or deploying a Goldsky Compose app — it is the reference layer that gives the concrete rules for how to build one: the exact shape of compose.yaml (every top-level, task, and trigger field), every `goldsky compose` CLI flag, the TaskContext API (env, fetch, callTask, logEvent, evm, collection), wallet APIs (smart wallet, BYO EOA), gas sponsorship, contract codegen, the dashboard URL, and pricing. Consult it before writing or editing any compose.yaml or task file — do not synthesize the manifest/CLI/API shape from memory — and also to answer any user question about how Compose works or what a field, flag, or API does. Pairs with /compose (the entry-point build guide, loaded first); use /compose-doctor to debug a broken app. Do NOT load for Turbo, Mirror, Subgraphs, or Edge — those have their own reference skills."
 ---
 
 # Goldsky Compose Reference
 
 Reference for the `compose.yaml` manifest, the full `goldsky compose` CLI surface, the `TaskContext` API, wallets, gas sponsorship, contract codegen, the dashboard, and pricing. For interactive build flows use `/compose`; for debugging use `/compose-doctor`.
+
+> This is the **reference layer** of the Compose skill family. `/compose` (loaded first) carries the general build rules and concepts; the template skills (`/compose-bitcoin-oracle`, `/compose-vrf`, `/compose-dividend-distribution`) carry example app source. Load this skill for any concrete field, flag, manifest shape, or API signature — and always before writing a `compose.yaml` or task file, rather than synthesizing the shape from memory.
 
 > **Always validate the manifest before deploying.** `goldsky compose dev` catches schema errors fast.
 
@@ -37,7 +39,7 @@ Most common lookups:
 | `api_version` | string               | deploy-only | semver (e.g. `0.1.0`) or `stable` / `preview` / `canary`                              |
 | `tasks`       | array                | yes         | Non-empty                                                                             |
 | `secrets`     | string[]             | no          | Names only — values set via `compose secret set`                                      |
-| `env`         | `{ local?, cloud? }` | no          | Each is `Record<string, string>`, flattened into `context.env`                        |
+| `env`         | `{ local?, cloud? }` | no          | **`env`'s only valid children are `local` and `cloud`** — each a `Record<string, string>` flattened into `context.env`. A bare `env.MY_VAR` (a var name directly under `env`) is rejected: "not a valid key". A hardcoded per-app constant belongs in the task file, not here. |
 
 ### Task fields
 

--- a/skills/compose/SKILL.md
+++ b/skills/compose/SKILL.md
@@ -1,11 +1,26 @@
 ---
 name: compose
-description: "Use this skill when the user asks about Goldsky Compose — the offchain-to-onchain TypeScript framework for onchain oracles, keepers, circuit breakers, and cross-chain automation. Triggers on: 'goldsky compose', 'compose.yaml', 'compose deploy/init/dev', 'compose task', 'cron task onchain', 'sponsored gas', 'writeContract from TypeScript', 'build a price oracle', 'resolve prediction market', 'onchain event listener', 'HTTP-triggered task', 'smart wallet'. Also use when the user wants to run TypeScript against EVM chains with managed gas, schedule onchain writes via cron, react to onchain events, or deploy a serverless task with secrets and a smart wallet. For debugging a broken app, use /compose-doctor. For manifest/CLI/API lookups, use /compose-reference. Do NOT trigger on Goldsky Turbo, Mirror, Subgraphs, Edge, or Datasets — those belong to their respective skills."
+description: "Always load this skill whenever the conversation is about Goldsky Compose (the offchain-to-onchain TypeScript framework for oracles, keepers, circuit breakers, and cross-chain automation) — no matter what the user wants to do with it. That includes: asking what Compose is, its docs, pricing, functionality, or limits; building, deploying, or iterating on an app; wiring cron / HTTP / onchain-event triggers, smart wallets, gas sponsorship, secrets, or collections; deploying a worked example; or debugging an existing app. This is the entry point for the Compose skill family — load it FIRST, then pull in the others it points to: /compose-reference for concrete manifest/CLI/API rules, a worked-example template (compose-bitcoin-oracle, compose-vrf, compose-dividend-distribution) when the user wants that specific app, and /compose-doctor for hands-on debugging. Do NOT load for Goldsky Turbo, Mirror, Subgraphs, Edge, or Datasets — those have their own skills."
 ---
 
 # Goldsky Compose
 
 Goldsky Compose is the offchain-to-onchain framework for high-stakes systems. Write TypeScript **tasks** that run in verifiable sandboxes — triggered by cron, HTTP, or onchain events — with smart wallets, gas sponsorship, and durable collections. Typical use cases: custom price oracles, keepers, circuit breakers, prediction-market resolvers, cross-chain automation, identity/attestation flows, and notifications.
+
+## Skill family — load `compose` first
+
+`compose` is the entry point for anything Goldsky Compose: **load it first, then pull in the others as needed.**
+
+- **General build rules and concepts** — this skill. It governs every Compose conversation, in-app or local.
+- **A specific example** (bitcoin oracle, VRF, dividend distribution) — also load the matching template (`/compose-bitcoin-oracle`, `/compose-vrf`, `/compose-dividend-distribution`). Each carries that app's source and specifics and relies on the rules here; it does not repeat them.
+- **Any field, flag, manifest shape, or API signature** — load `/compose-reference`. It's the full reference docs. Consult it before writing any `compose.yaml` or task file.
+- **A broken app** — `/compose-doctor`.
+
+## Golden rules (all modes, including the in-app deploy card)
+
+- **Never assume anything about the app on the user's behalf.** Derive what you can from what the user actually said; for anything material to how the app is built or behaves that you cannot derive — contract address, chain, ABI, trigger cadence, wallet choice, secret values — **ask the user**. Do not invent it, guess it, or carry a value over from an example.
+- **Never synthesize the manifest, CLI, or API shape from memory.** Load `/compose-reference` and follow it before emitting `compose.yaml` or a task file. This applies equally to the in-app `deployComposeApp` flow.
+- **When unsure about anything that affects how the app works, ask rather than proceed.**
 
 ## Boundaries
 


### PR DESCRIPTION
## Context

FOU-982: the in-app deploy of the sample bitcoin-oracle failed with `Invalid manifest: env.ORACLE_CONTRACT is not a valid key. Top-level keys must be 'local' or 'cloud'`. The chatbot put a per-app constant under `env:` as a bare key and got the shape wrong.

The guidance to prevent this already half-existed (the template said "load `/compose-reference`" and the reference already documented `env` correctly) yet the manifest was still synthesized wrong. This PR restructures the Compose skill family so the rules that must hold live in one always-loaded place, fixes the frontmatter so the LLM actually loads those skills at the right time, and makes the exact failing shape explicit in the docs.

## Changes

**`compose` — the entry point for the family**
- *Description (full rewrite):* now loads for **any** Compose conversation — asking what it is / docs / pricing / functionality, building, deploying, or debugging — and names itself the entry point to load first, pointing to `/compose-reference`, the worked-example templates, and `/compose-doctor`.
- *Body:* adds a **Skill family** section (load `compose` first, then a template for a specific example, `/compose-reference` for any field or shape before writing a `compose.yaml`/task, `/compose-doctor` for debugging) and **Golden rules** that apply to all modes including the in-app deploy card: never assume app details on the user's behalf (ask for contract/chain/ABI/cadence/wallet/secrets you can't derive; never invent or carry over from an example), never synthesize the manifest/CLI/API shape from memory, ask when unsure.

**`compose-reference` — the reference layer**
- *Description (full rewrite):* now loads whenever building/editing/deploying an app to get the concrete build rules and manifest/API shape (not only Q&A lookups), and for answering questions about how Compose works.
- *Body:* framed as the reference layer of the family, and the `env` field row now spells out that its only valid children are `local`/`cloud`, a bare `env.MY_VAR` is rejected, and per-app constants belong in the task file.

## Why frontmatter mattered

The `description` is what the LLM reads to decide which skills to load; the body only takes effect once loaded. The original `compose-reference` triggers were all Q&A-framed, so during an actual build (like FOU-982) the model had no signal to load it. Both descriptions were rewritten so loading is driven at selection time, not just documented in the body.

## Scope

Hierarchy + rules only, `compose` and `compose-reference` only. Template slimming (bitcoin-oracle / vrf / dividend) and the app-specific "address is a `const`, no `env` block" fix are handled separately — the templates also need their descriptions updated to name `compose` as a prerequisite.

## Not yet verified

Descriptions **bias** loading, they don't guarantee order — there is no priority field that forces `compose` to load first. And whether the production in-app chatbot actually consumes these skills and honors them is unconfirmed. Recommend re-running the sample-oracle seed prompt in-app after this ships before closing FOU-982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)