### PR TITLE
Align bitcoin-oracle + vrf templates to the compose skill hierarchy

### DIFF
--- a/skills/compose-bitcoin-oracle/SKILL.md
+++ b/skills/compose-bitcoin-oracle/SKILL.md
@@ -7,20 +7,19 @@ description: "Build and deploy the Goldsky Compose bitcoin-oracle example under 
 
 Stand up the bitcoin-oracle example under the user's own Goldsky account. A cron task fetches BTC/USD from CoinGecko and writes `(timestamp, price * 100)` as two `bytes32` values to a `PriceOracle` contract via a Compose-managed wallet. It also appends the price to a Compose `collection` for historical queries.
 
-This skill is the single source of truth for the procedure. It merges the runnable example in `goldsky-io/documentation-examples` (`compose/bitcoin-oracle`) with the in-app seed-prompt flow. The recommended path uses a **shared, fully-unpermissioned `PriceOracle` on Base Sepolia**, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored. Assume the user has never used Goldsky Compose before. Do not skip preflight.
+This template supplies only what's specific to the bitcoin-oracle app — how it works and its source. It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes — consult before writing any `compose.yaml` or task) govern this build and are not repeated here. The recommended path uses a **shared, fully-unpermissioned `PriceOracle` on Base Sepolia**, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
 
 ## Mode Detection
 
 Pick the mode from the tools available to you:
 
-- **A `deployComposeApp` tool is available (Goldsky webapp chatbot) — this is the preferred in-app flow.** Do NOT emit `goldsky` terminal commands or `cliCommand` cards, and do NOT use Step 0 / `degit` / `forge` / `goldsky compose deploy`. Instead: give a 2-3 sentence plain explanation, then ask the config questions one at a time with `askUser` (tag the recommended option with `recommendedIndex`):
-  1. **App name** (recommend `bitcoin-oracle`).
-  2. **Contract** — ask this explicitly, do not assume: *"Do you have your own `PriceOracle` contract, or should we use a shared demo oracle on Base Sepolia to get running quickly?"* Options: **"Use the shared demo oracle on Base Sepolia (recommended — nothing to deploy)"** and **"I'll use my own contract."** On the shared path, `ORACLE_CONTRACT` is the **HARDCODED** address `0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113` on `baseSepolia` — copy it character-for-character, do NOT alter or retype it from memory; mention in prose that it's demos-only, not production. On the own path, ask the user to paste their contract address and chain, and use exactly what they paste (their `PriceOracle` must let the Compose wallet write).
-  3. **Update frequency** (recommend every minute, `* * * * *`).
+- **A `deployComposeApp` tool is available (Goldsky webapp chatbot) — this is the preferred in-app flow.** Do NOT emit `goldsky` terminal commands or `cliCommand` cards, and do NOT use Step 0 / `degit` / `forge` / `goldsky compose deploy`. **Do NOT ask the user what to name the app** — name it `bitcoin-oracle` automatically; they can rename it after deploy. Give a 2-3 sentence plain explanation, then ask with `askUser` (tag the recommended option with `recommendedIndex`):
+  1. **Contract** — ask this explicitly, do not assume: *"Do you have your own `PriceOracle` contract, or should we use a shared demo oracle on Base Sepolia to get running quickly?"* Options: **"Use the shared demo oracle on Base Sepolia (recommended — nothing to deploy)"** and **"I'll use my own contract."** On the shared path, `ORACLE_CONTRACT` is the **HARDCODED** address `0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113` on `baseSepolia` — copy it character-for-character; mention in prose it's demos-only, not production. On the own path, ask the user to paste their contract address and chain and use exactly what they paste (their `PriceOracle` must let the Compose wallet write).
+  2. **Update frequency** (recommend every minute, `* * * * *`).
 
-  The Compose smart wallet is auto-created at runtime and gas-sponsored — never tell the user to create or fund a wallet. After the interview, scaffold the files in-memory and pass them to `deployComposeApp` (do NOT degit): `compose.yaml` (a single cron task on the chosen schedule), `src/contracts/PriceOracle.json` (the verbatim ABI in Step 3), and `src/tasks/bitcoin-oracle.ts` (fetch BTC/USD from CoinGecko, then `evm.contracts.PriceOracle.write(toBytes32(timestamp), toBytes32(Math.round(price*100)))` on the chosen chain via the gas-sponsored smart wallet, wired to `ORACLE_CONTRACT`, appending each price to a `bitcoin_prices` collection). **First load `/compose-reference`** for the manifest schema and the sandbox import rule, then write these files following them — do not invent the manifest shape or import external packages (`evm`/`fetch`/`collection` come from the injected `context`; the only imports allowed are `compose` and sibling files). Then **call `deployComposeApp` in the SAME turn to present the in-app deploy card** — do not ask the user to confirm first, do not emit any `goldsky` command, and do not make them run anything in a terminal. After the deploy card, print nothing else. **In this mode, ignore Steps 0–8 below entirely** — they are the CLI/local procedure.
-- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parse output, and substitute captured values into later commands.
-- **Neither (pure reference Q&A):** explain what the app does; only if asked for step-by-step help, output one command at a time and have the user paste output back. Point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
+  The Compose smart wallet is auto-created at runtime and gas-sponsored — never tell the user to create or fund a wallet. After the questions, scaffold the files in-memory (do NOT degit): `compose.yaml` (a single cron task on the chosen schedule), `src/contracts/PriceOracle.json` (the verbatim ABI in Step 3), and `src/tasks/bitcoin-oracle.ts` (fetch BTC/USD from CoinGecko, then `evm.contracts.PriceOracle.write(toBytes32(timestamp), toBytes32(Math.round(price*100)))` via the gas-sponsored smart wallet, appending each price to a `bitcoin_prices` collection). `ORACLE_CONTRACT` is a **hardcoded `const` at the top of the task file, not an env var** — do not put it under the manifest `env:` key. Follow `/compose-reference` for the manifest shape and the sandbox import rule before emitting the files (per the golden rules in `/compose` — don't synthesize the manifest from memory). Then **call `deployComposeApp` in the SAME turn**; don't ask the user to confirm first or emit any `goldsky` command. **In this mode, ignore Steps 0–8 below** — they are the CLI/local procedure.
+- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parsing output into later commands.
+- **Neither (pure reference Q&A):** explain what the app does; for step-by-step help point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
 
 ## Non-negotiables
 
@@ -29,10 +28,6 @@ Pick the mode from the tools available to you:
 - **Deploy-your-own path only:** the contract's authorized writer must be the Compose wallet, or every `write()` reverts. On the shared-oracle path there is no writer restriction, so this does not apply.
 - **The example ships only `src/contracts/PriceOracle.json` (the ABI), not Solidity source.** If deploying fresh, use the reference contract in this skill. Write the ABI verbatim — see Step 3.
 - **Do not touch `src/lib/utils.ts`.** `toBytes32` is coupled to how the contract stores the value.
-
-## Variable handling for agents
-
-When this skill says `$FOO`, capture the literal value from the prior command's output and substitute it directly into the next command. Do not rely on shell variables persisting between separate Bash tool invocations — each invocation gets a fresh shell with no env carryover from earlier commands.
 
 > **Steps 0–8 below are the Bash / local-CLI procedure. If a `deployComposeApp` tool is available (webapp chatbot), do NOT follow them — use the deploy-tool flow in Mode Detection above.**
 
@@ -56,21 +51,17 @@ If the user already cloned the example, skip this step and `cd` into it.
 
 ## Preflight
 
-1. **`goldsky` CLI** — `goldsky --version`. Install per https://docs.goldsky.com/reference/cli.
-2. **`goldsky` authenticated** — `goldsky project list`. If it errors, stop and tell the user: "Please run `goldsky login` in your terminal — browser flow. Tell me to continue when you see the success message." Do not spawn `goldsky login` from Bash; it requires an interactive browser.
-3. **`deno`** — `deno --version`. `curl -fsSL https://deno.land/install.sh | sh` if missing.
-4. **`foundry`** — `forge --version`. Only needed on the deploy-your-own path.
+The `goldsky` CLI, auth, and `deno` checks are the standard Compose preflight — see `/compose` and `/auth-setup`. Bitcoin-oracle-specific: **`foundry`** (`forge --version`) is needed only on the deploy-your-own path (Step 3, Branch B).
 
-## Step 1 — Configuration interview
+## Step 1 — Configuration
 
-Ask one question at a time; let each answer inform the next. Use readable labels and translate to machine values yourself.
+Name the app `bitcoin-oracle` (don't ask). Then, per the golden rules in `/compose`, ask only what you can't derive:
 
-1. **"App name?"** (recommend `bitcoin-oracle`) → top-level `name:` in `compose.yaml`.
-2. **"Which chain?"** — **Base Sepolia (recommended)** because it has the ready, fully-unpermissioned shared oracle (nothing to deploy). Other options (Base, Arbitrum, Polygon Amoy, etc.) require deploying your own oracle. Use the camelCase form in TS (`baseSepolia`).
-3. **"PriceOracle contract?"** (ask immediately after the chain) — two options:
+1. **"Which chain?"** — **Base Sepolia (recommended)** because it has the ready, fully-unpermissioned shared oracle (nothing to deploy). Other options (Base, Arbitrum, Polygon Amoy, etc.) require deploying your own oracle. Use the camelCase form in TS (`baseSepolia`).
+2. **"PriceOracle contract?"** (ask immediately after the chain) — two options:
    - **Reuse the shared oracle on Base Sepolia (recommended)** — nothing to deploy. Wire `0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113` (mention the address in prose, not in any option label). Demos/getting-started only, not production.
    - **Deploy my own** — see Step 3, Branch B. (Required on any chain other than Base Sepolia.)
-4. **"How often should the cron run?"** — Every minute (recommended, `* * * * *`), every 5 minutes (`*/5 * * * *`), or every hour. Set the `expression:` under the `cron` trigger in `compose.yaml`.
+3. **"How often should the cron run?"** — Every minute (recommended, `* * * * *`), every 5 minutes (`*/5 * * * *`), or every hour. Set the `expression:` under the `cron` trigger in `compose.yaml`.
 
 ## Step 2 — Wallet
 

--- a/skills/compose-vrf/SKILL.md
+++ b/skills/compose-vrf/SKILL.md
@@ -7,7 +7,7 @@ description: "Build and deploy the Goldsky Compose VRF (verifiable random functi
 
 Stand up the VRF example under the user's own Goldsky account. The app listens for a `RandomnessRequested(uint256,address)` event on an EVM contract, fetches verifiable randomness from the **drand** beacon (BLS12-381 threshold signatures, verifiable by anyone), and writes it back on-chain via `fulfillRandomness(requestId, randomness, round, signature)`. Trust comes from the stored drand `round` + `signature`, not from the caller, so the shared example contract is safe to leave open.
 
-This skill is the single source of truth for the procedure and carries the **full app source below** (manifest, contract, ABI, both trigger tasks, and the drand helper). The recommended path uses a **shared, fully-unpermissioned `RandomnessConsumer` on Base Sepolia** at `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d`, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored. Assume the user has never used Goldsky Compose before. Do not skip preflight.
+This template supplies only what's specific to the VRF app — how it works and its **full source** (below). It's part of the Compose skill family: **load `/compose` first.** Its golden rules (never assume anything about the app on the user's behalf; ask when unsure) and `/compose-reference` (manifest / field / API shapes — consult before writing any `compose.yaml` or task) govern this build and are not repeated here. The recommended path uses a **shared, fully-unpermissioned `RandomnessConsumer` on Base Sepolia** at `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d`, so the user deploys nothing and the Compose smart wallet is auto-created and gas-sponsored.
 
 ## Mode Detection
 
@@ -16,9 +16,9 @@ Pick the mode from the tools available to you:
 - **A `deployComposeApp` tool is available (Goldsky webapp chatbot) — this is the preferred in-app flow.** Do NOT emit `goldsky` terminal commands or `cliCommand` cards, and do NOT use Step 0 / `degit` / `forge` / `goldsky compose deploy`. Instead: give a 2-3 sentence plain explanation, then ask the **single** config question below with `askUser` (tag the recommended option with `recommendedIndex`). **Do NOT ask the user what to name the app** — name it `vrf-app` automatically; they can rename it after it's deployed. Ask only:
   - **Contract** — ask this explicitly, do not assume: *"Do you have your own `RandomnessConsumer`-style contract, or should we use a shared demo contract on Base Sepolia to get running quickly?"* Options: **"Use the shared demo contract on Base Sepolia (recommended — nothing to deploy)"** and **"I'll use my own contract."** On the shared path, `CONTRACT_ADDRESS` is the **HARDCODED** address `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d` on `baseSepolia` — copy it character-for-character, do NOT alter or retype it from memory; mention in prose that it's demos-only, not production. On the own path, ask the user to paste their contract address and chain (their contract must emit `RandomnessRequested(uint256,address)` and accept `fulfillRandomness`), and use exactly what they paste.
 
-  The Compose smart wallet is auto-created at runtime and gas-sponsored on Base Sepolia — never tell the user to create or fund a wallet. On the shared path there is **no fulfiller to set** (the contract is permissionless), so the wallet just works. After the single question, scaffold the files in-memory from **The app (full source)** below and pass them to `deployComposeApp` (do NOT degit): `compose.yaml`, `src/contracts/RandomnessConsumer.json` (the verbatim ABI, required for contract codegen), `src/lib/drand.ts`, `src/tasks/fulfill-randomness.ts`, `src/tasks/request-randomness.ts`, and `src/tasks/generate-wallet.ts`. Set the top-level `name:` in `compose.yaml` to `vrf-app`. Set `CONTRACT_ADDRESS` in both task files and the `contract:` field in `compose.yaml` to the shared address (or the user's, on the own path); set the `evm.chains.*` reference and the trigger `network:` to the chosen chain. **First load `/compose-reference`** for the manifest schema and the sandbox import rule, then emit the files following them — do not invent the manifest shape. The tasks import only from `compose` and the sibling `../lib/drand.ts`; `evm` and `fetch` come from the injected `context`, never from npm. Then **call `deployComposeApp` in the SAME turn to present the in-app deploy card** — do not ask the user to confirm first, do not emit any `goldsky` command, and do not make them run anything in a terminal. After the deploy card, print nothing else. **In this mode, ignore Steps 0–8 below entirely** — they are the CLI/local procedure.
-- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parse output, and substitute captured values into later commands.
-- **Neither (pure reference Q&A):** explain what the app does; only if asked for step-by-step help, output one command at a time and have the user paste output back. Point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
+  The Compose smart wallet is auto-created at runtime and gas-sponsored on Base Sepolia — never tell the user to create or fund a wallet. On the shared path there is **no fulfiller to set** (the contract is permissionless), so the wallet just works. After the single question, scaffold these files in-memory from **The app (full source)** below and pass them to `deployComposeApp` (do NOT degit): `compose.yaml`, `src/contracts/RandomnessConsumer.json` (verbatim ABI, required for codegen), `src/lib/drand.ts`, and the three task files. Set the top-level `name:` to `vrf-app`; set `CONTRACT_ADDRESS` in both task files and the `contract:` field in `compose.yaml` to the shared address (or the user's, on the own path), and the `evm.chains.*` reference + trigger `network:` to the chosen chain. Follow `/compose-reference` for the manifest shape and the sandbox import rule before emitting the files (per the golden rules in `/compose` — don't synthesize the manifest from memory). Then **call `deployComposeApp` in the SAME turn**; don't ask the user to confirm first or emit any `goldsky` command. **In this mode, ignore Steps 0–8 below** — they are the CLI/local procedure.
+- **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parsing output into later commands.
+- **Neither (pure reference Q&A):** explain what the app does; for step-by-step help point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
 
 ## Non-negotiables
 
@@ -27,10 +27,6 @@ Pick the mode from the tools available to you:
 - **Three places share the contract address:** the `contract:` field in `compose.yaml`, and `CONTRACT_ADDRESS` in both `src/tasks/fulfill-randomness.ts` and `src/tasks/request-randomness.ts`. If the user changes it, change all three.
 - **Deploy-your-own path only:** the drand fulfillment is permissionless in the reference contract, but if the user's own contract restricts fulfillment, the authorized fulfiller must be the Compose wallet or every `fulfillRandomness` reverts. On the shared contract there is no such restriction.
 - **Never run `forge create`, `goldsky compose deploy`, `git push`, or `gh repo create` without showing the exact command first and getting explicit confirmation.**
-
-## Variable handling for agents
-
-When this skill says `$FOO`, capture the literal value from the prior command's output and substitute it directly into the next command. Do not rely on shell variables persisting between separate Bash tool invocations — each invocation gets a fresh shell with no env carryover from earlier commands.
 
 ## The app (full source)
 
@@ -500,12 +496,7 @@ If the user already cloned the example, skip this step and `cd` into it. Either 
 
 ## Preflight
 
-Run these checks in order. Stop and resolve each before moving on.
-
-1. **`goldsky` CLI** — `goldsky --version`. Install per https://docs.goldsky.com/reference/cli.
-2. **`goldsky` authenticated** — `goldsky project list`. If it errors, stop and tell the user: "Please run `goldsky login` in your terminal — browser flow. Tell me to continue when you see the success message." Do not spawn `goldsky login` from Bash; it requires an interactive browser.
-3. **`deno`** — `deno --version`. `curl -fsSL https://deno.land/install.sh | sh` if missing.
-4. **`foundry`** — `forge --version`. Only needed on the deploy-your-own path.
+The `goldsky` CLI, auth, and `deno` checks are the standard Compose preflight — see `/compose` and `/auth-setup`. VRF-specific: **`foundry`** (`forge --version`) is needed only on the deploy-your-own path (Step 3, Branch B).
 
 ## Step 1 — Configuration interview
 


### PR DESCRIPTION
Pairs with #44 (the compose skill-family hierarchy). Slims the `compose-bitcoin-oracle` and `compose-vrf` worked-example templates so they defer to the always-loaded `compose` skill and `compose-reference` rather than repeating them.

Per the new hierarchy, a template "just supplies the specific information of how that app works and its source; the always-injected skills fill in the rest." So each template now:
- Leads with "load `/compose` first" and notes its golden rules (never assume on the user's behalf; ask when unsure) + `compose-reference` (manifest/field/API shapes) govern the build and aren't repeated.
- Drops the duplicated "load compose-reference for the manifest schema + sandbox import rule / don't invent the manifest" boilerplate (now owned by `compose`/`compose-reference`), and — for bitcoin-oracle — keeps a one-line app-specific note that `ORACLE_CONTRACT` is a hardcoded const, not an `env:` key (the FOU-982 failure).
- Trims the generic preflight (CLI/auth/deno → `compose` + `auth-setup`), keeping only app-specific tools (foundry).
- Removes the generic variable-handling note.
- Stops asking the user to name the app (auto-names it; rename after deploy).
- Keeps the app-specific description, **full source**, steps, and troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)