### PR TITLE
fix(turbo-transforms): correct Solana instruction decoding guidance

### DIFF
--- a/skills/turbo-transforms/references/solana-patterns.md
+++ b/skills/turbo-transforms/references/solana-patterns.md
@@ -25,6 +25,8 @@ Custom (Anchor) programs identify each instruction by an 8-byte discriminator an
 
 > **Solana column names.** Solana rows use `block_slot`, `block_timestamp`, and `signature` — **not** `block_number` or `transaction_hash`. The per-instruction dataset is `solana.instructions` (columns include `id`, `program_id`, `data`, `accounts`, `block_slot`, `signature`).
 
+> **⚠️ Never fabricate program IDs or token mints.** The `program_id` / mint addresses in `filter:` and `WHERE program_id = '…'` are base58 Solana addresses — get them from the user, or look them up (e.g. a token mint via a token API); **never emit one from memory.** A guessed address is silently wrong: the pipeline validates and deploys fine but matches nothing (or the wrong program). If you don't have a verified address, ask the user to paste it rather than inventing one.
+
 ### Decoding custom programs with an IDL
 
 Use `_gs_decode_instruction_data(idl, data)`. Fetch the IDL from a URL with `_gs_fetch_abi` (pass it inline for very small IDLs):

--- a/skills/turbo-transforms/references/solana-patterns.md
+++ b/skills/turbo-transforms/references/solana-patterns.md
@@ -2,9 +2,32 @@
 
 ## Solana Transform Patterns
 
-### Decoding Solana Instructions with IDL
+### How Solana decoding works (read this first)
 
-Use `_gs_decode_instruction_data()` with a program's IDL to decode instruction data:
+A Solana instruction has three parts:
+
+- `program_id` — the program that runs
+- `accounts` — the account public keys the instruction touches (an array)
+- `data` — an **opaque byte array**: an instruction selector followed by its arguments
+
+In Goldsky's Solana datasets the instruction bytes live in a column literally named **`data`** (not `instruction_data`), and its value is a **base58 string**. That base58 is only the *transport encoding of the raw bytes* — it is **not** decoded meaning.
+
+> **⚠️ base58 is not decoding.** Base58-decoding `data` yourself only turns the string back into raw bytes; it does **not** give you the instruction name or parameters. There is no universal instruction layout on Solana — each program defines its own — so you must decode with something that knows the program's schema. Do **not** try to decode instructions with `_gs_from_base58`. Pass the base58 `data` column *directly* to one of the decoders below; they base58-decode, read the selector, and deserialize internally.
+
+**Pick your decoder by `program_id`:**
+
+| Program type | Decoder | Needs an IDL? |
+| --- | --- | --- |
+| Native / SPL (Token, System, Stake, Vote, Associated Token, BPF Loader, Address Lookup Table) | `_gs_solana_decode_<program>_instruction(data, accounts)` | No — layouts are built in |
+| Any custom program (DEX, DeFi, NFT — Jupiter, Raydium, Drift, …) | `_gs_decode_instruction_data(idl, data)` | Yes — fetch with `_gs_fetch_abi(url, 'raw')` |
+
+Custom (Anchor) programs identify each instruction by an 8-byte discriminator and Borsh-encode the arguments; the IDL is the schema that maps those bytes to names and values.
+
+> **Solana column names.** Solana rows use `block_slot`, `block_timestamp`, and `signature` — **not** `block_number` or `transaction_hash`. The per-instruction dataset is `solana.instructions` (columns include `id`, `program_id`, `data`, `accounts`, `block_slot`, `signature`).
+
+### Decoding custom programs with an IDL
+
+Use `_gs_decode_instruction_data(idl, data)`. Fetch the IDL from a URL with `_gs_fetch_abi` (pass it inline for very small IDLs):
 
 ```yaml
 transforms:
@@ -14,78 +37,72 @@ transforms:
     sql: |
       SELECT
         id,
-        block_number,
+        program_id,
         _gs_decode_instruction_data(
-          '{"version":"0.1.0","name":"my_program","instructions":[...]}',
-          instruction_data
+          _gs_fetch_abi('https://example.com/raydium-idl.json', 'raw'),
+          data
         ) AS decoded,
-        transaction_hash
+        accounts,
+        block_slot,
+        signature
       FROM solana_instructions
-      WHERE program_id = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      WHERE program_id = 'CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C'
 ```
 
-The returned struct has `decoded.name` (instruction name) and `decoded.value` (decoded parameters).
+The returned struct has `decoded.name` (instruction/event name) and `decoded.value` (a JSON string of the parameters — extract fields with `json_value(decoded.value, '$.amountIn')`). The function attempts instruction decoding first and falls back to event decoding.
 
-### Decoding Solana Logs
+### Decoding Solana logs
 
 ```sql
 _gs_decode_log_message(
-  '{"version":"0.1.0","name":"my_program","events":[...]}',
+  _gs_fetch_abi('https://example.com/program-idl.json', 'raw'),
   log_messages
 ) AS decoded_log
 ```
 
-### Program-Specific Decoders (No IDL Needed)
+Works best with Anchor programs that emit structured events. The IDL must match the deployed program version.
 
-These built-in decoders handle common Solana programs without requiring an IDL:
+### Program-specific decoders (no IDL needed)
+
+Built-in decoders for common native/SPL programs. **Every one takes `(data, accounts)`** and returns a struct with `.name` and `.value`:
 
 ```sql
--- SPL Token Program (transfers, mints, burns)
-gs_solana_decode_token_program_instruction(instruction_data)
-
--- System Program (SOL transfers, account creation)
-gs_solana_decode_system_program_instruction(instruction_data)
-
--- Associated Token Account Program
-gs_solana_decode_associated_token_program_instruction(instruction_data)
-
--- Stake Program
-gs_solana_decode_stake_program_instruction(instruction_data)
-
--- Vote Program
-gs_solana_decode_vote_program_instruction(instruction_data)
-
--- Extract accounts from transaction data
-gs_solana_get_accounts(transaction_data)
-
--- Extract balance changes
-gs_solana_get_balance_changes(transaction_data)
+_gs_solana_decode_token_program_instruction(data, accounts)             -- SPL Token: transfers, mints, burns
+_gs_solana_decode_system_program_instruction(data, accounts)            -- System: SOL transfers, account creation
+_gs_solana_decode_associated_token_program_instruction(data, accounts)  -- Associated Token Account
+_gs_solana_decode_stake_program_instruction(data, accounts)             -- Stake
+_gs_solana_decode_vote_program_instruction(data, accounts)              -- Vote
+_gs_solana_decode_bpf_loader_instruction(data, accounts)                -- BPF loader
+_gs_solana_decode_bpf_upgradeable_loader_instruction(data, accounts)    -- Upgradeable programs
+_gs_solana_decode_address_lookup_table_instruction(data, accounts)      -- Address lookup tables
 ```
 
-### Example — Track SPL Token Transfers on Solana
+For unified account lists and SOL balance changes, see `_gs_solana_get_accounts(...)` and `_gs_solana_get_balance_changes(...)` in the [SQL functions reference](https://docs.goldsky.com/turbo-pipelines/reference/sql-functions#solana-functions).
+
+### Example — Track SPL token transfers on Solana
 
 ```yaml
 name: solana-spl-tracker
 resource_size: s
 
 sources:
-  sol_txns:
+  solana_ix:
     type: dataset
-    dataset_name: solana.transactions_with_instructions
+    dataset_name: solana.instructions
     version: 1.0.0
-    start_at: latest
+    # omit start_block to start from the latest slot
 
 transforms:
-  token_instructions:
+  decoded_token_ops:
     type: sql
     primary_key: id
     sql: |
       SELECT
         id,
-        block_number,
-        transaction_hash,
-        gs_solana_decode_token_program_instruction(instruction_data) AS decoded
-      FROM sol_txns
+        block_slot,
+        signature,
+        _gs_solana_decode_token_program_instruction(data, accounts) AS decoded
+      FROM solana_ix
       WHERE program_id = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
 
   transfers_only:
@@ -94,11 +111,11 @@ transforms:
     sql: |
       SELECT
         id,
-        block_number,
-        transaction_hash,
+        block_slot,
+        signature,
         decoded.name AS instruction_type,
         decoded.value AS params
-      FROM token_instructions
+      FROM decoded_token_ops
       WHERE decoded.name = 'Transfer'
 
 sinks:
@@ -107,12 +124,12 @@ sinks:
     from: transfers_only
 ```
 
-### Base58 Decoding
+### `_gs_from_base58` — raw bytes only, NOT instruction decoding
 
-Convert Solana base58-encoded data to binary:
+`_gs_from_base58` converts a base58 string to its raw binary bytes. Use it for low-level byte work on addresses or signatures — **never** as a way to decode instruction `data`. To decode an instruction, use an IDL (`_gs_decode_instruction_data`) or a program-specific decoder (above).
 
 ```sql
-_gs_from_base58('3Bxs3zy...')  -- returns BINARY
+_gs_from_base58('3Bxs3zy...')  -- returns BINARY (raw bytes, NOT a decoded instruction)
 ```
 
 ---


### PR DESCRIPTION
## Why

The Solana decoding section of `turbo-transforms/references/solana-patterns.md` had multiple errors that would make every copied snippet fail — and a failing agent naturally falls back to guessing (base58-decoding everything). Reviewed against the [SQL functions reference](https://docs.goldsky.com/turbo-pipelines/reference/sql-functions#solana-functions).

## What was wrong

1. **Wrong column name** — snippets passed `instruction_data`, but the real column in `solana.instructions` (and the nested `instructions[]` structs) is **`data`**. → "Column not found."
2. **Wrong decoder names + arity** — used `gs_solana_decode_*(instruction_data)`, but the functions are `_gs_solana_decode_*` (leading underscore) and take **`(data, accounts)`** (two args).
3. **base58 framed as "decoding"** — a "Base58 Decoding" heading pointed at `_gs_from_base58` with no warning that base58 is just the transport encoding, not a decoder.
4. **Wrong Solana row columns** — examples used `block_number` / `transaction_hash` (EVM) and `start_at: latest` (invalid for Solana).

## What changed

- Corrected column names, decoder names, and decoder arity throughout.
- Rewrote the base58 section into an explicit **"base58 is NOT decoding"** warning.
- Added a mental model + **decision tree** (native/SPL built-in decoder vs. IDL decode) at the top of the section.
- Switched IDL loading to `_gs_fetch_abi(url, 'raw')` and fixed the SPL example to use `solana.instructions` with `block_slot` / `signature`.

Scope is limited to `solana-patterns.md`; the corresponding docs-page updates are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
