### PR TITLE
docs: AGENTS.md + README BYO-agent section for cross-agent discoverability (APP-4993)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+<!--
+  Entry point for AI coding agents. Kept in sync with SKILLS.md (the canonical
+  skill index) by hand — if you add/rename/remove a skill, update both.
+  Humans should read README.md instead.
+-->
+
+# AGENTS.md — Goldsky Agent
+
+Guide for AI coding agents (Devin, Codex, Cursor, Amp, Claude Code, and anything else that reads `AGENTS.md`). This repo is a **skill pack** for building, deploying, and debugging on Goldsky — Turbo pipelines, Mirror pipelines, Subgraphs, Compose, and Edge RPC. Each skill is a self-contained folder of step-by-step instructions plus reference material.
+
+## How to use these skills
+
+Some hosts (Claude Code, Cursor) auto-discover skills and trigger them from each skill's `description`. **If your runtime has no "skills" feature, use them manually — they are just Markdown:**
+
+1. Identify the task (build a pipeline, fix a broken one, write a transform, deploy/repair a subgraph, build a Compose app…).
+2. Open the matching `skills/<name>/SKILL.md` (routing table below; full index in [`SKILLS.md`](./SKILLS.md)).
+3. Follow it. A `SKILL.md` points into deeper files under `skills/<name>/references/` and `skills/<name>/templates/` — read those when it tells you to.
+4. For **reference lookups** (CLI flags, YAML fields, dataset names, error codes), query the Goldsky **docs MCP** at `https://docs.goldsky.com/mcp` rather than guessing. Every published doc is also in `https://docs.goldsky.com/llms.txt`.
+
+Each `SKILL.md` opens with a `description:` in its frontmatter stating what it covers and when to use it — scan those to route.
+
+## Skill routing
+
+| If the task is… | Use skill |
+| --- | --- |
+| Build/deploy a new Turbo pipeline (chain → dataset → transforms → sink) | `turbo-builder` |
+| A Turbo pipeline is broken / not getting data / output looks wrong | `turbo-doctor` |
+| Turbo YAML syntax, sources/sinks, architecture & sizing decisions | `turbo-pipelines` |
+| Write a SQL / TypeScript / dynamic-table transform (incl. EVM & Solana decoding) | `turbo-transforms` |
+| Pause / restart / delete a pipeline; interpret a pipeline error | `turbo-operations` |
+| Sync a subgraph entity source to a DB; Mirror vs Turbo | `mirror` |
+| A Mirror pipeline is failing / stuck / terminated | `mirror-doctor` |
+| Author / build / deploy a subgraph; schema, mappings, manifest | `subgraph-builder` |
+| A subgraph stopped syncing / won't deploy / errors | `subgraph-doctor` |
+| Migrate a subgraph off The Graph | `subgraph-migrate` |
+| Build a Compose app (oracle / keeper / automation) in TypeScript | `compose` |
+| A Compose app is crashlooping / not processing tasks | `compose-doctor` |
+| `compose.yaml` fields, `goldsky compose` flags, `TaskContext` API | `compose-reference` |
+| Worked example: onchain BTC/USD price oracle | `compose-bitcoin-oracle` |
+| Worked example: onchain verifiable randomness (VRF) | `compose-vrf` |
+| Get a fast, reliable managed RPC endpoint; RPC error codes | `edge` |
+| Find the right dataset name / chain prefix | `datasets` |
+| Store credentials for a sink (Postgres, ClickHouse, Kafka…) | `secrets` |
+| Install the CLI / log in / switch projects / fix `unauthorized` | `auth-setup` |
+
+Canonical list with descriptions: [`SKILLS.md`](./SKILLS.md).
+
+## Gotchas agents get wrong — read before generating code
+
+- **A green validate is not proof it works.** After generating a pipeline, run `goldsky turbo validate` before presenting it — but validation checks YAML/SQL *shape*, not *correctness* (right addresses, real event signatures, sane volume). Don't claim it works on the strength of validation alone.
+- **Never invent onchain identifiers.** EVM contract addresses (`0x…`), Solana program IDs, and token mints (base58) must come from the user or a real lookup — **never from memory**. A guessed address validates and deploys fine but silently matches nothing (or the wrong thing). If you don't have a verified one, ask the user to paste it.
+- **Solana decoding is not base58.** Instruction `data` is base58-encoded *bytes* — base58-decoding it gives you raw bytes, **not** the decoded instruction. Decode by passing the base58 `data` directly to an IDL decoder (`_gs_decode_instruction_data(idl, data)`) or a program-specific decoder (`_gs_solana_decode_*(data, accounts)`). See `skills/turbo-transforms/references/solana-patterns.md`.
+- **Prefer Turbo over Mirror** for new pipelines. Reach for Mirror only when you specifically need a subgraph entity source — the one thing Turbo can't do.
+
+## Install (for agents that support it)
+
+```bash
+# Copies skills into your project for 30+ supported agents:
+npx skills add goldsky-io/goldsky-agent
+
+# From the docs site — also exposes skills as MCP resources and at /.well-known/skills:
+npx skills add https://docs.goldsky.com
+```
+
+If your agent supports MCP, connect the Goldsky docs MCP directly: `https://docs.goldsky.com/mcp`.
+
+## Links
+
+- Canonical skill index: [`SKILLS.md`](./SKILLS.md)
+- Human-facing overview: [`README.md`](./README.md)
+- Docs: https://docs.goldsky.com — MCP: `https://docs.goldsky.com/mcp` — `llms.txt`: https://docs.goldsky.com/llms.txt

--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ cp -r goldsky-agent/skills/* .cursor/skills/    # Cursor
 
 </details>
 
+## Use with autonomous or BYO agents
+
+Claude Code and Cursor auto-discover these skills and trigger them from each skill's `description`. **Autonomous or bring-your-own-model agents** — Devin, Codex, custom LLM apps — don't implement that convention. Installing isn't enough: `npx skills add` copies the skills into a skills directory (`.claude/skills/` for a single Claude Code target, or the shared `.agents/skills/` when targeting several) but writes **no** entry-point file telling an agent to look there. Bridge that one of two ways:
+
+- **Connect the docs MCP** (recommended) — any MCP-capable agent can search the docs and discover the skills (exposed as MCP resources) at query time. Devin: add it under `mcpServers` in `.devin/config.json` (see [Devin's MCP docs](https://docs.devin.ai/work-with-devin/mcp)). Setup for other clients is under [MCP Server](#mcp-server) below.
+- **Install the skills, then add an `AGENTS.md`** at your project root so agents that read it (Devin, Codex, Amp, …) know the skills exist — point it at your install path:
+
+```markdown
+# AGENTS.md
+
+This project uses Goldsky. AI-agent skills for building, deploying, and
+debugging Goldsky pipelines are installed under `.agents/skills/` (or
+`.claude/skills/`). Before a Goldsky task, read the matching
+`<skills-dir>/<name>/SKILL.md` and the files it references. For reference
+lookups, query the Goldsky docs MCP: https://docs.goldsky.com/mcp
+```
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
## Why

Skills only auto-surface inside hosts that implement the *skills convention* (Claude Code's `Skill` tool, Cursor's skills dir). Autonomous / BYO agents (Devin, Codex, custom LLM apps) don't — and installing the skills isn't enough: `npx skills add` copies them into a skills directory (`.claude/skills/` for a single target, `.agents/skills/` for multi-agent) but writes no entry-point file telling an agent to look there.

## What

Two goldsky-agent changes for cross-agent discoverability:

1. **Root `AGENTS.md`** — the cross-agent entry point (Devin, Codex, Cursor, Amp, Claude Code, …): how to consume skills manually (`skills/<name>/SKILL.md` + `references/`), a task→skill routing table with `SKILLS.md` as canonical, and the docs MCP for reference lookups. Kept in sync with `SKILLS.md` by hand (noted in an HTML comment).
2. **README "Use with autonomous or BYO agents" section** — the human/source-of-truth version: explains that BYO agents don't auto-discover, that install writes no entry-point file, and the two ways to bridge (connect the docs MCP, or install + add a project-root `AGENTS.md`). References the existing MCP Server section rather than duplicating it.

The customer-facing docs mirror of this lives in goldsky-io/docs#462 (`ai-skills.mdx`) — separate because the sync workflow only copies `skills/` bodies, not README/overview prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
