### PR TITLE
feat: compliance oracle skill — payment model, provider, and chain flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ End-to-end worked examples — each carries the full app source and walks build 
 | `compose-bitcoin-oracle` | "Build a BTC/USD price oracle that writes onchain" | Cron task → CoinGecko → `PriceOracle` contract via a Compose wallet; collection for history |
 | `compose-vrf` | "Build a verifiable random function / onchain randomness" | Event-triggered task → drand beacon → `fulfillRandomness` on a `RandomnessConsumer` contract, verifiable by anyone |
 | `compose-dividend-distribution` | "Distribute dividends / a corporate action to token holders pro-rata" | HTTP task orchestrates a Turbo job-mode pipeline to snapshot holders at a record block, then pays each pro-rata onchain (CLI-driven) |
-| `compose-compliance-oracle` | "Build a compliance-gated payment system with wallet screening" | Onchain-event task → escrow contract → Webacy AML screening → oracle approve/reject callback, plus a reconcile cron; deploy-your-own (oracle-permissioned), recommended on Base Sepolia + MockUSDC |
+| `compose-compliance-oracle` | "Build a compliance-gated payment system with wallet screening" | Onchain-event task → escrow contract → compliance screening (Webacy/mock/BYO) → oracle approve/reject callback; single-payee or P2P; any EVM chain; plus a reconcile cron |
 
 ### Edge (managed RPC)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -31,7 +31,7 @@ End-to-end worked examples — each carries the full app source and walks build 
 - **compose-bitcoin-oracle** - Cron task writing BTC/USD from CoinGecko to an onchain `PriceOracle` contract
 - **compose-vrf** - Fetches verifiable randomness from drand and fulfills onchain `RandomnessRequested` events
 - **compose-dividend-distribution** - Pays token holders pro-rata for a corporate action; Compose orchestrates a Turbo job-mode pipeline to snapshot holders, then pays each onchain
-- **compose-compliance-oracle** - Compliance-gated payments: escrow contract + Webacy AML screening + oracle approve/reject callback, plus a reconcile cron. Deploy-your-own (oracle-permissioned), recommended on Base Sepolia + MockUSDC
+- **compose-compliance-oracle** - Compliance-gated payments: escrow contract + compliance screening (Webacy/mock/BYO) + oracle approve/reject callback; single-payee or P2P; any EVM chain; plus a reconcile cron
 
 ### Edge (managed RPC)
 - **edge** - Managed RPC endpoints, capabilities, supported chains, error code lookups

--- a/skills/compose-compliance-oracle/SKILL.md
+++ b/skills/compose-compliance-oracle/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: compose-compliance-oracle
-description: "Build and deploy the Goldsky Compose compliance-oracle example under the user's own account — a compliance-gated payment gateway where a smart contract holds a USDC payment in escrow, Compose screens the sender wallet via the Webacy AML API on the emitted TransferRequested event, then calls back to approve (funds to the business wallet) or reject (funds returned to sender). Ships a second cron task that reconciles stuck transfers. Triggers on: 'build a compliance oracle', 'compliance-gated payments', 'AML screening onchain', 'KYC payment gateway', 'escrow with compliance check', 'wallet screening oracle', 'gated transfers', 'Webacy oracle'. The escrow contract's approve/reject are oracle-permissioned, so there is no shared no-deploy contract — each user deploys their own instance bound to their oracle wallet (recommended path: Base Sepolia + a MockUSDC). The oracle signs via a private-key secret with sponsored gas. For a custom/novel Compose app, use /compose. For debugging a deployed app, use /compose-doctor. For manifest/CLI/API field lookups, use /compose-reference."
+description: "Build and deploy the Goldsky Compose compliance-oracle example under the user's own account — a compliance-gated payment system where a smart contract holds funds in escrow, Compose screens the sender wallet via a compliance API (Webacy recommended, or bring-your-own / mock), then calls back to approve or reject. Supports two payment models: single-payee (payment gateway — funds go to a configurable recipient) and multi-payee (P2P — sender specifies recipient per transfer). Ships a second cron task that reconciles stuck transfers. Triggers on: 'build a compliance oracle', 'compliance-gated payments', 'AML screening onchain', 'KYC payment gateway', 'escrow with compliance check', 'wallet screening oracle', 'gated transfers', 'Webacy oracle', 'P2P compliance', 'payment gateway with screening'. The escrow contract's approve/reject are oracle-permissioned, so there is no shared no-deploy contract — each user deploys their own instance bound to their oracle wallet (recommended path: Base Sepolia + a MockUSDC). The oracle signs via a private-key secret with sponsored gas. For a custom/novel Compose app, use /compose. For debugging a deployed app, use /compose-doctor. For manifest/CLI/API field lookups, use /compose-reference."
 ---
 
 # Build: Compose compliance-oracle
 
-Stand up the compliance payment gateway under the user's own Goldsky account. A `ComplianceGatedTransfer` contract accepts a USDC payment from any sender and holds it in escrow, emitting `TransferRequested`. Compose reacts to that event, screens the sender wallet via the **Webacy** AML API, then signs a callback: `approveTransfer` (escrowed funds go to the oracle/business wallet) or `rejectTransfer` (funds returned to the sender). Every decision is written to a durable `transfer-audits` collection, and a `reconcile` cron catches transfers left stuck in `Pending`. Gas is sponsored — the oracle wallet never needs native token.
+Stand up a compliance-gated payment system under the user's own Goldsky account. A `ComplianceGatedTransfer` contract accepts a payment from any sender and holds it in escrow, emitting `TransferRequested`. Compose reacts to that event, screens the sender wallet via a compliance API, then signs a callback: `approveTransfer` (funds go to the intended recipient) or `rejectTransfer` (funds returned to the sender). Every decision is written to a durable `transfer-audits` collection, and a `reconcile` cron catches transfers left stuck in `Pending`. Gas is sponsored — the oracle wallet never needs native token.
 
-This template supplies only what's specific to the compliance app — how it works and its **full source** (below). Unlike the VRF or bitcoin-oracle examples, **there is no shared no-deploy contract**: `approveTransfer`/`rejectTransfer` are `onlyOracle`-gated (that's the security model — only the oracle may release escrow), so each instance is bound at construction to one oracle address. Every user deploys their own contract with their own oracle wallet as `oracle`. The recommended path is **Base Sepolia** with a `MockUSDC` you deploy, so it's free and fully gas-sponsored; graduate to Base mainnet with native USDC for production.
+**Two payment models** (chosen during configuration):
+- **Single-payee** (payment gateway / deposit flow) — all approved funds go to one configurable `recipient` address, set at construction and changeable via `setRecipient()`. The recipient is separate from the oracle signer.
+- **Multi-payee** (P2P transfers) — the sender specifies a recipient per transfer via `requestTransfer(amount, recipient)`.
+
+**Three compliance provider options:**
+- **Webacy (recommended)** — simple REST API, one API key. Sign up at https://developers.webacy.co/ for a free demo key.
+- **Mock mode** — hardcoded allow/deny list, no API key needed. Good for testing the flow before committing to a provider.
+- **Bring your own** — scaffolds the `screenWallet()` interface for you to implement with any provider.
+
+This template supplies only what's specific to the compliance app — how it works and its **full source** (below). Unlike the VRF or bitcoin-oracle examples, **there is no shared no-deploy contract**: `approveTransfer`/`rejectTransfer` are `onlyOracle`-gated (that's the security model — only the oracle may release escrow), so each instance is bound at construction to one oracle address. Every user deploys their own contract with their own oracle wallet as `oracle`. The recommended path is **Base Sepolia** with a `MockUSDC` you deploy, so it's free and fully gas-sponsored; graduate to mainnet for production. Any EVM chain Compose supports works — Base Sepolia is recommended because it's free and gas-sponsored.
 
 ## Step 0a — Load the base skills first
 
@@ -99,7 +108,11 @@ tasks:
 
 ### `contracts/ComplianceGatedTransfer.sol`
 
-Single-payee escrow: on approval, funds go to the `oracle` (business) wallet; on rejection, back to the sender. Imports OpenZeppelin's `IERC20` (installed in Preflight).
+**Use the single-payee OR P2P variant below based on the user's choice in Step 1.** Only scaffold one.
+
+#### Single-payee variant
+
+On approval, funds go to a configurable `recipient` address (separate from the oracle signer); on rejection, back to the sender. Imports OpenZeppelin's `IERC20` (installed in Preflight).
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -116,8 +129,9 @@ contract ComplianceGatedTransfer {
         Status status;
     }
 
-    IERC20 public immutable usdc;
+    IERC20 public immutable token;
     address public oracle;
+    address public recipient;
     uint256 public nextTransferId;
 
     mapping(uint256 => Transfer) public transfers;
@@ -129,6 +143,7 @@ contract ComplianceGatedTransfer {
     );
     event TransferApproved(uint256 indexed id);
     event TransferRejected(uint256 indexed id);
+    event RecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
     event OracleUpdated(address indexed oldOracle, address indexed newOracle);
 
     modifier onlyOracle() {
@@ -136,18 +151,15 @@ contract ComplianceGatedTransfer {
         _;
     }
 
-    constructor(address _usdc, address _oracle) {
-        usdc = IERC20(_usdc);
+    constructor(address _token, address _oracle, address _recipient) {
+        token = IERC20(_token);
         oracle = _oracle;
+        recipient = _recipient;
     }
 
-    /// @notice User calls this to send a compliance-screened payment.
-    ///         User must have approved this contract to spend `amount` of USDC first.
-    ///         If approved, funds go to the oracle (business) wallet.
     function requestTransfer(uint256 amount) external {
         require(amount > 0, "zero amount");
-
-        usdc.transferFrom(msg.sender, address(this), amount);
+        token.transferFrom(msg.sender, address(this), amount);
 
         uint256 id = nextTransferId++;
         transfers[id] = Transfer({
@@ -159,25 +171,27 @@ contract ComplianceGatedTransfer {
         emit TransferRequested(id, msg.sender, amount);
     }
 
-    /// @notice Oracle approves the transfer — funds go to the oracle (business) wallet.
     function approveTransfer(uint256 id) external onlyOracle {
         Transfer storage t = transfers[id];
         require(t.status == Status.Pending, "not pending");
         t.status = Status.Approved;
-        usdc.transfer(oracle, t.amount);
+        token.transfer(recipient, t.amount);
         emit TransferApproved(id);
     }
 
-    /// @notice Oracle rejects the transfer — funds returned to sender.
     function rejectTransfer(uint256 id) external onlyOracle {
         Transfer storage t = transfers[id];
         require(t.status == Status.Pending, "not pending");
         t.status = Status.Rejected;
-        usdc.transfer(t.sender, t.amount);
+        token.transfer(t.sender, t.amount);
         emit TransferRejected(id);
     }
 
-    /// @notice Allow oracle address to be updated (for key rotation).
+    function setRecipient(address _recipient) external onlyOracle {
+        emit RecipientUpdated(recipient, _recipient);
+        recipient = _recipient;
+    }
+
     function setOracle(address _oracle) external onlyOracle {
         emit OracleUpdated(oracle, _oracle);
         oracle = _oracle;
@@ -185,9 +199,94 @@ contract ComplianceGatedTransfer {
 }
 ```
 
-### `contracts/MockUSDC.sol` (Base Sepolia / recommended path only)
+#### Multi-payee (P2P) variant
 
-Native USDC only exists on mainnet. On Base Sepolia, deploy this mintable 6-decimal ERC-20 first and use its address as the escrow's `_usdc` constructor arg. Open `mint` so you can fund sender wallets freely on testnet.
+The sender specifies a recipient per transfer. On approval, funds go to the transfer's `recipient`; on rejection, back to the sender. No `setRecipient` — each transfer carries its own.
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract ComplianceGatedTransfer {
+    enum Status { Pending, Approved, Rejected }
+
+    struct Transfer {
+        address sender;
+        address recipient;
+        uint256 amount;
+        Status status;
+    }
+
+    IERC20 public immutable token;
+    address public oracle;
+    uint256 public nextTransferId;
+
+    mapping(uint256 => Transfer) public transfers;
+
+    event TransferRequested(
+        uint256 indexed id,
+        address indexed sender,
+        address indexed recipient,
+        uint256 amount
+    );
+    event TransferApproved(uint256 indexed id);
+    event TransferRejected(uint256 indexed id);
+    event OracleUpdated(address indexed oldOracle, address indexed newOracle);
+
+    modifier onlyOracle() {
+        require(msg.sender == oracle, "not oracle");
+        _;
+    }
+
+    constructor(address _token, address _oracle) {
+        token = IERC20(_token);
+        oracle = _oracle;
+    }
+
+    function requestTransfer(uint256 amount, address _recipient) external {
+        require(amount > 0, "zero amount");
+        require(_recipient != address(0), "zero recipient");
+        token.transferFrom(msg.sender, address(this), amount);
+
+        uint256 id = nextTransferId++;
+        transfers[id] = Transfer({
+            sender: msg.sender,
+            recipient: _recipient,
+            amount: amount,
+            status: Status.Pending
+        });
+
+        emit TransferRequested(id, msg.sender, _recipient, amount);
+    }
+
+    function approveTransfer(uint256 id) external onlyOracle {
+        Transfer storage t = transfers[id];
+        require(t.status == Status.Pending, "not pending");
+        t.status = Status.Approved;
+        token.transfer(t.recipient, t.amount);
+        emit TransferApproved(id);
+    }
+
+    function rejectTransfer(uint256 id) external onlyOracle {
+        Transfer storage t = transfers[id];
+        require(t.status == Status.Pending, "not pending");
+        t.status = Status.Rejected;
+        token.transfer(t.sender, t.amount);
+        emit TransferRejected(id);
+    }
+
+    function setOracle(address _oracle) external onlyOracle {
+        emit OracleUpdated(oracle, _oracle);
+        oracle = _oracle;
+    }
+}
+```
+
+### `contracts/MockUSDC.sol` (testnet / recommended path only)
+
+Native USDC only exists on mainnet. On testnets, deploy this mintable 6-decimal ERC-20 first and use its address as the escrow's `_token` constructor arg. Open `mint` so you can fund sender wallets freely on testnet.
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -306,9 +405,77 @@ export async function screenWallet(
 }
 ```
 
+### `src/lib/mock-screener.ts` (mock mode only)
+
+Use this instead of `webacy.ts` when the user chose mock mode. Same `WalletScreeningResult` interface, no API key needed.
+
+```typescript
+import { TaskContext } from "compose";
+
+export type WalletScreeningResult = {
+  address: string;
+  riskScore: number | null;
+  passed: boolean;
+  triggeredRules: string[];
+};
+
+// Add addresses to this set to simulate flagged/risky wallets
+const DENY_LIST = new Set<string>([
+  "0x000000000000000000000000000000000000dead",
+  // Add your test "risky" addresses here (lowercase)
+]);
+
+export async function screenWallet(
+  address: string,
+  _apiKey: string,
+  riskThreshold: number,
+  _fetchFn: TaskContext["fetch"],
+): Promise<WalletScreeningResult> {
+  const isRisky = DENY_LIST.has(address.toLowerCase());
+
+  return {
+    address,
+    riskScore: isRisky ? 85 : 5,
+    passed: !isRisky,
+    triggeredRules: isRisky ? ["Deny list match"] : [],
+  };
+}
+```
+
+### `src/lib/screener.ts` (bring-your-own mode only)
+
+Scaffold this interface for the user to implement with their own provider. Same `WalletScreeningResult` interface.
+
+```typescript
+import { TaskContext } from "compose";
+
+export type WalletScreeningResult = {
+  address: string;
+  riskScore: number | null;
+  passed: boolean;
+  triggeredRules: string[];
+};
+
+export async function screenWallet(
+  address: string,
+  _apiKey: string,
+  riskThreshold: number,
+  fetchFn: TaskContext["fetch"],
+): Promise<WalletScreeningResult> {
+  // TODO: Implement your screening logic here.
+  // Use fetchFn (not fetch/axios) for any HTTP calls — Compose sandboxes network access.
+  //
+  // Return { passed: true } to approve, { passed: false } to reject.
+  // riskScore and triggeredRules are for audit logging.
+  throw new Error("Not implemented — replace with your screening provider");
+}
+```
+
+> **Provider swap:** all three providers export the same `screenWallet` function signature and `WalletScreeningResult` type. The task imports from whichever provider was chosen — change the import in `on-transfer-requested.ts` to swap: `"../lib/webacy"`, `"../lib/mock-screener"`, or `"../lib/screener"`.
+
 ### `src/tasks/on-transfer-requested.ts`
 
-The main task. Decodes the event, screens the sender, signs `approveTransfer`/`rejectTransfer` via the private-key oracle wallet (gas-sponsored), and writes an audit record.
+The main task. Decodes the event, screens the sender, signs `approveTransfer`/`rejectTransfer` via the private-key oracle wallet (gas-sponsored), and writes an audit record. **The import path for the screener depends on the provider choice.** The P2P variant differs only in the event type and decoding — see the note after the source.
 
 ```typescript
 import { TaskContext, OnchainEvent } from "compose";
@@ -433,6 +600,14 @@ export async function main(ctx: TaskContext, payload: OnchainEvent) {
 }
 ```
 
+> **P2P variant changes:** For the multi-payee contract, change the event type and decoding in `on-transfer-requested.ts`:
+> - Event type: `args: { id: bigint; sender: string; recipient: string; amount: bigint }`
+> - Add `{ name: "recipient", type: "address", indexed: true }` to the ABI inputs (between sender and amount)
+> - Destructure: `const { id, sender, recipient, amount } = decoded.args;`
+> - Update `compose.yaml` event signature to `TransferRequested(uint256,address,address,uint256)`
+>
+> The rest of the task (screening, approve/reject, audit record) is identical — the contract handles routing funds to `transfer.recipient`.
+
 ### `src/tasks/reconcile.ts`
 
 A safety-net cron (every 5 minutes). Scans the contract for transfers stuck in `Pending` — an event the main task missed or a failed callback — and logs an alert so nothing sits in escrow silently.
@@ -515,7 +690,18 @@ mkdir -p compliance-oracle/src/tasks compliance-oracle/src/lib compliance-oracle
 cd compliance-oracle
 ```
 
-Write these files verbatim from the source above: `compose.yaml`, `tsconfig.json`, `foundry.toml`, `contracts/ComplianceGatedTransfer.sol`, `contracts/MockUSDC.sol`, `src/lib/constants.ts`, `src/lib/webacy.ts`, `src/tasks/on-transfer-requested.ts`, and `src/tasks/reconcile.ts`. Then wire the deployed address and chain in Step 3. Add a `.gitignore` containing `.env`, `node_modules/`, and `.compose/`.
+Write these files verbatim from the source above — choose the correct contract variant (single-payee or P2P) and screening provider (webacy.ts, mock-screener.ts, or screener.ts) based on the user's choices in Step 1. Update the import in `on-transfer-requested.ts` to match the chosen provider. Files to write: `compose.yaml`, `tsconfig.json`, `foundry.toml`, `contracts/ComplianceGatedTransfer.sol` (chosen variant), `contracts/MockUSDC.sol` (testnet only), `src/lib/constants.ts`, the chosen screening library, `src/tasks/on-transfer-requested.ts`, and `src/tasks/reconcile.ts`. Then wire the deployed address and chain in Step 3.
+
+Add a `.gitignore`:
+
+```
+.env
+.compose/
+cache/
+lib/
+out/
+node_modules/
+```
 
 ## Preflight
 
@@ -539,9 +725,16 @@ The `goldsky` CLI and auth checks are the standard Compose preflight — see `/c
 Per the golden rules in `/compose`, ask only what you can't derive, one question at a time — and ask the app name first:
 
 1. **"What should the app be called? (suggest `compliance-oracle`)"** — ask FIRST, before any wallet or contract step. The name is hard to change later: it scopes named wallets and participates in the CREATE2 salt for every `deployContract` (Step 2), so it must be settled now. Accept the default `compliance-oracle` on a shrug, and set it as the top-level `name:` in `compose.yaml`.
-2. **"Which chain?"** — **Base Sepolia (recommended)** — free, gas-sponsored, and you mint your own test USDC. Base mainnet is production (real USDC, real screening, real funds). Use the camelCase form in TS (`baseSepolia`) and snake_case in `compose.yaml` (`base_sepolia`).
-3. **"What risk threshold?"** — Webacy `overallRisk` is 0-100; senders scoring at or above the threshold are rejected. Default `50`. Set `RISK_THRESHOLD` in `src/lib/constants.ts`.
-4. **Recipient** — approved funds go to the **oracle (business) wallet** itself (the contract sends escrow to `oracle` on approval). That's the `oracle` set at construction — the `ORACLE_PRIVATE_KEY` EOA, not the Compose wallet that performs the deploy. No separate recipient to configure.
+2. **"Is this a single-payee system (like a payment gateway or deposit flow) or a multi-payee system (like P2P transfers)?"**
+   - **Single payee (recommended for getting started)** — all approved payments go to one configured `recipient` address. The recipient is separate from the oracle and can be updated on the contract independently via `setRecipient()`. Use the single-payee contract variant and `TransferRequested(uint256,address,uint256)` event.
+   - **Multi payee (P2P)** — the sender specifies the recipient per transfer. Use the P2P contract variant and `TransferRequested(uint256,address,address,uint256)` event.
+3. **"Which compliance/wallet screening API do you want to use?"**
+   - **Webacy (recommended)** — simple REST API, one API key. Sign up at https://developers.webacy.co/ — you can create a demo API key right after signup.
+   - **Mock mode** — hardcoded allow/deny list, no API key needed. Good for testing the flow before committing to a provider. Remove `WEBACY_API_KEY` from `compose.yaml`'s `secrets` array.
+   - **Bring your own** — scaffolds the `screenWallet()` function signature; you fill in the body.
+4. **"Which chain?"** — **Base Sepolia (recommended)** — free, gas-sponsored, and you mint your own test USDC. Any EVM chain Compose supports works (Ethereum Sepolia, Polygon Amoy, Arbitrum Sepolia, etc. for testnet; Base, Ethereum, Polygon, Arbitrum, Optimism, etc. for mainnet). Use the camelCase form in TS (`baseSepolia`) and the compose network name in `compose.yaml` (`base_sepolia`).
+5. **"What risk threshold?"** — Risk score is 0-100; senders scoring at or above the threshold are rejected. Default `50`. Set `RISK_THRESHOLD` in `src/lib/constants.ts`.
+6. **Recipient (single-payee only)** — **"What address should approved payments be sent to?"** They can provide an address now, or use the oracle/deployer wallet address for testing (simplest — "I'll use the oracle wallet for now"). This can be changed later via `setRecipient()` on the contract. The recipient becomes the third constructor arg.
 
 ## Step 2 — Oracle wallet and contract deploy
 
@@ -560,11 +753,11 @@ echo "Oracle address: $ORACLE_ADDRESS"   # the ONLY thing ever printed
 shred -u /tmp/k.json
 ```
 
-Also add the RPC URL and Webacy key to `.env` (never commit this file):
+Also add the RPC URL and screening key to `.env` (never commit this file). Omit `WEBACY_API_KEY` if using mock mode:
 
 ```env
-RPC_URL=https://sepolia.base.org   # or https://mainnet.base.org for production; used by the cast alternative in Step 7
-WEBACY_API_KEY=your_webacy_api_key
+RPC_URL=https://sepolia.base.org   # or the RPC for the user's chosen chain; used by the cast alternative in Step 7
+WEBACY_API_KEY=your_webacy_api_key  # omit for mock mode
 ```
 
 `ORACLE_ADDRESS` is already set if you ran the block above; in a fresh shell, re-derive it from `.env` — it is the `oracle` constructor arg, and the contract's `approveTransfer`/`rejectTransfer` must be signed by this same key at runtime:
@@ -577,16 +770,26 @@ ORACLE_ADDRESS=$(cast wallet address "$ORACLE_PRIVATE_KEY")
 **Base Sepolia (recommended): deploy a MockUSDC first**, then use its address as the escrow's `_usdc` arg. Both deploys go through the gas-sponsored Compose wallet (Base Sepolia is sponsored, so nothing needs funding) — `deployContract` only changes who deploys; the `oracle` is still the `ORACLE_PRIVATE_KEY` EOA above. (Each `deployContract`/`writeContract` needs a project API key — pass `-t <key>` or have an active `goldsky login` session; generate the key at **Settings > API Keys** in the Goldsky dashboard.)
 
 ```bash
-# 1) MockUSDC — no constructor args
-goldsky compose deployContract contracts/MockUSDC.sol --chain-id 84532
-# capture the printed address as $USDC_ADDRESS
+# 1) MockUSDC — no constructor args (testnet only)
+goldsky compose deployContract contracts/MockUSDC.sol --chain-id $CHAIN_ID
+# capture the printed address as $TOKEN_ADDRESS
 
-# 2) ComplianceGatedTransfer(usdc, oracle) — oracle is the ORACLE_PRIVATE_KEY EOA
+# 2) ComplianceGatedTransfer — constructor args depend on the payment model:
+
+# Single-payee (3 args: token, oracle, recipient):
 goldsky compose deployContract contracts/ComplianceGatedTransfer.sol \
-  --chain-id 84532 \
-  --constructor-args $USDC_ADDRESS $ORACLE_ADDRESS
+  --chain-id $CHAIN_ID \
+  --constructor-args $TOKEN_ADDRESS $ORACLE_ADDRESS $RECIPIENT_ADDRESS
+
+# P2P (2 args: token, oracle):
+goldsky compose deployContract contracts/ComplianceGatedTransfer.sol \
+  --chain-id $CHAIN_ID \
+  --constructor-args $TOKEN_ADDRESS $ORACLE_ADDRESS
+
 # capture the printed address as $CONTRACT_ADDRESS
 ```
+
+Use the chain ID for the user's chosen chain (e.g. `84532` for Base Sepolia, `8453` for Base mainnet, `11155111` for Ethereum Sepolia, etc.).
 
 The ABI for each contract is auto-saved to `src/contracts/<Name>.json`. Once both deploys print `Address:`, generate the typed contract classes (required before any typecheck — the `tsconfig.json` `paths` entry points at `.compose/types.d.ts`, which codegen produces):
 
@@ -596,42 +799,44 @@ goldsky compose codegen
 
 > **TypeScript pin:** the inlined `tsconfig.json` typechecks on **TypeScript 5.x** — TS 6 rejects `baseUrl`. If you run a typecheck, pin `npx -y typescript@5 tsc` rather than a bare `tsc`.
 
-**Base mainnet (production):** skip MockUSDC — pass native USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` straight in as `$USDC_ADDRESS`:
+**Mainnet (production):** skip MockUSDC — use the native token address on the user's chosen chain (e.g. USDC on Base is `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`). Ask the user for the token contract address and use it as `$TOKEN_ADDRESS` directly.
 
-```bash
-goldsky compose deployContract contracts/ComplianceGatedTransfer.sol \
-  --chain-id 8453 \
-  --constructor-args 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 $ORACLE_ADDRESS
-```
-
-Capture `$CONTRACT_ADDRESS` and `$USDC_ADDRESS` for the next step, then run `goldsky compose codegen` here too.
+Capture `$CONTRACT_ADDRESS` and `$TOKEN_ADDRESS` for the next step, then run `goldsky compose codegen` here too.
 
 ## Step 3 — Wire the contract address and chain into the app
 
 Two files reference the chain/addresses. Use grep anchors — line numbers shift.
 
 **`src/lib/constants.ts`:**
-- `chain:` → `"baseSepolia"` (Base Sepolia) or leave `"base"` (mainnet).
+- `chain:` → the user's chosen chain in camelCase (e.g. `"baseSepolia"`, `"base"`, `"polygonAmoy"`, etc.).
 - `contractAddress:` → `$CONTRACT_ADDRESS`.
-- `usdcAddress:` → `$USDC_ADDRESS` (your MockUSDC on Sepolia; native USDC on mainnet).
+- `usdcAddress:` → `$TOKEN_ADDRESS` (your MockUSDC on testnet; native token on mainnet).
 
 **`compose.yaml`** (inside the `on_transfer_requested` trigger):
-- `network:` → `"base_sepolia"` or `"base"` (snake_case).
+- `network:` → the compose network name for the user's chain (e.g. `"base_sepolia"`, `"base"`, `"polygon_amoy"`, etc.).
 - `contract:` → `$CONTRACT_ADDRESS`.
 
-The event signature `TransferRequested(uint256,address,uint256)` stays as-is — it matches the contract. Show a diff before applying, then apply with Edit.
+The event signature should match the chosen contract variant:
+- Single-payee: `TransferRequested(uint256,address,uint256)` (already the default)
+- P2P: `TransferRequested(uint256,address,address,uint256)`
+
+Show a diff before applying, then apply with Edit.
 
 Note: `src/lib/webacy.ts` hardcodes `?chain=base` in its Webacy request deliberately — testnet screening reuses mainnet reputation data, so leave it `base` even on Base Sepolia (the source comment doesn't say so).
 
 ## Step 4 — Set Compose secrets
 
-The running app needs the oracle key (to sign callbacks) and the Webacy key (to screen). If you haven't already, now's the one thing only you can do — sign up at https://developers.webacy.co/ and create an API key; park it until here. (The whole flow through Step 3 was verified working with a stub key, so a placeholder is fine right up to this point.)
+The running app needs the oracle key (to sign callbacks). If using Webacy, it also needs the API key.
 
 ```bash
 source .env
 goldsky compose secret set ORACLE_PRIVATE_KEY --value "$ORACLE_PRIVATE_KEY"
+
+# Webacy mode only — skip for mock mode:
 goldsky compose secret set WEBACY_API_KEY --value "$WEBACY_API_KEY"
 ```
+
+If using Webacy and you haven't signed up yet, do it now at https://developers.webacy.co/ — you can create a demo API key right after signup.
 
 ## Step 5 — Optional: publish to a new GitHub repo
 


### PR DESCRIPTION
## Summary

Adds three key design options to the compliance oracle skill, all tested end-to-end locally with an agent building the full app from the skill:

- **Payment model choice**: single-payee (payment gateway with configurable `recipient` address, separate from oracle signer) vs multi-payee (P2P — sender specifies recipient per transfer). Full Solidity source for both contract variants.
- **Compliance provider choice**: Webacy (recommended, easy signup at developers.webacy.co) / mock mode (hardcoded deny list, no API key) / bring-your-own (scaffolded `screenWallet()` interface). All three share the same function signature — swappable via import path.
- **Chain flexibility**: any EVM chain Compose supports, not hardcoded to Base / Base Sepolia. Chain ID passed to `deployContract`, chain names parameterized in constants and compose.yaml.

Also adds a `.gitignore` template (`.compose/`, `cache/`, `lib/`, `out/`, `node_modules/`, `.env`) and expands the config interview with the new decision points.

## Test plan

- [x] Built a full P2P compliance oracle app from this skill using a fresh agent session
- [x] Contract compiled and deployed via `goldsky compose deployContract`
- [x] Smoke tested with `writeContract` — transfer requested, screened, approved/rejected
- [x] Verified mock screening provider works without Webacy API key
- [x] Verified single-payee variant with separate recipient address

🤖 Generated with [Claude Code](https://claude.com/claude-code)