### PR TITLE
feat: dividend in-app + compliance Compose-wallet oracle + secrets-last

### DIFF
--- a/skills/compose-compliance-oracle/SKILL.md
+++ b/skills/compose-compliance-oracle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-compliance-oracle
-description: "Build and deploy the Goldsky Compose compliance-oracle example under the user's own account — a compliance-gated payment gateway where a smart contract holds a USDC payment in escrow, Compose screens the sender wallet via the Webacy AML API on the emitted TransferRequested event, then calls back to approve (funds to the business wallet) or reject (funds returned to sender). Ships a second cron task that reconciles stuck transfers. Triggers on: 'build a compliance oracle', 'compliance-gated payments', 'AML screening onchain', 'KYC payment gateway', 'escrow with compliance check', 'wallet screening oracle', 'gated transfers', 'Webacy oracle'. The escrow contract's approve/reject are oracle-permissioned, so there is no shared no-deploy contract — each user deploys their own instance bound to their oracle wallet (recommended path: Base Sepolia + a MockUSDC). The oracle signs via a private-key secret with sponsored gas. For a custom/novel Compose app, use /compose. For debugging a deployed app, use /compose-doctor. For manifest/CLI/API field lookups, use /compose-reference."
+description: "Build and deploy the Goldsky Compose compliance-oracle example under the user's own account — a compliance-gated payment gateway where a smart contract holds a USDC payment in escrow, Compose screens the sender wallet via the Webacy AML API on the emitted TransferRequested event, then calls back to approve (funds to the business wallet) or reject (funds returned to sender). Ships a second cron task that reconciles stuck transfers. Triggers on: 'build a compliance oracle', 'compliance-gated payments', 'AML screening onchain', 'KYC payment gateway', 'escrow with compliance check', 'wallet screening oracle', 'gated transfers', 'Webacy oracle'. The escrow contract's approve/reject are oracle-permissioned, so there is no shared no-deploy contract — each user deploys their own instance bound to their oracle wallet (recommended path: Base Sepolia + a MockUSDC). The oracle is a named Compose smart wallet (`compliance-oracle-wallet`, gas-sponsored) with no private key to manage on the default path. For a custom/novel Compose app, use /compose. For debugging a deployed app, use /compose-doctor. For manifest/CLI/API field lookups, use /compose-reference."
 ---
 
 # Build: Compose compliance-oracle
@@ -22,7 +22,7 @@ This template deliberately omits those rules and that reference — they are **r
 
 Pick the mode from the tools available to you:
 
-- **A `deployComposeApp` tool is available (Goldsky webapp chatbot).** This example **cannot be fully stood up through the in-app deploy card**, and that is expected — say so plainly. Two hard reasons: (1) it requires an `ORACLE_PRIVATE_KEY` secret (and a `WEBACY_API_KEY`) that only the `goldsky` CLI / dashboard can set, and (2) the Compose app is useless until an oracle-bound `ComplianceGatedTransfer` contract is deployed on-chain — and that contract must be constructed with the oracle wallet's address, which means deploying it first via `goldsky compose deployContract`. The in-app card does neither. So do NOT scaffold files or call `deployComposeApp`. Instead: give a 3-4 sentence explanation of what the app does and why it's CLI-driven, then walk the user through the CLI steps below (or tell them to run this skill locally with `npx skills add goldsky-io/goldsky-agent` where a `Bash` tool is available). Everything from **The app (full source)** down is that CLI procedure.
+- **A `deployComposeApp` tool is available (Goldsky webapp chatbot).** Compliance now deploys fully in-app. In-app flow: run the Step 1 interview (app name first), `walletCreate({ appName: "<chosen app name>", walletName: "compliance-oracle-wallet" })` to get the oracle wallet address (pass `appName` as the chosen app name and `walletName` explicitly; passing the wallet name positionally as `appName` creates the wrong app scope, and the resulting address never matches the runtime `evm.wallet({ name: "compliance-oracle-wallet" })`), `deployContract` MockUSDC, then `deployContract` ComplianceGatedTransfer with `constructorArgs: ["<USDC_addr>", "<oracle-wallet-addr>"]` (these are tool inputs: `sources` and `constructorArgs`, not CLI flags). Wire the deployed contract address and chain into the inlined source (Step 3), then `deployComposeApp`. The `WEBACY_API_KEY` secret is the user's LAST step: the in-app deploy skips secret validation, so `deployComposeApp` succeeds without it, but the app won't run until the user adds the secret in the Compose app's dashboard **and redeploys from the dashboard** so the pod picks it up (secrets are baked into the pod at deploy, not hot-reloaded). NEVER attempt to set a secret from chat; there is no tool, by design. Scaffold the inlined source from **The app (full source)** below in-memory.
 - **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parse output, and substitute captured values into later commands.
 - **Neither (pure reference Q&A):** explain what the app does and the escrow → screen → approve/reject lifecycle; only if asked for step-by-step help, output one command at a time and have the user paste output back. Point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
 
@@ -33,11 +33,21 @@ When this skill says `$FOO`, capture the literal value from the prior command's 
 ## Non-negotiables
 
 - **There is no shared, reusable contract.** `approveTransfer`, `rejectTransfer`, and `setOracle` are all `onlyOracle` (`require(msg.sender == oracle)`), and `oracle` is fixed at construction. A user cannot point their app at someone else's deployed instance — only that instance's oracle key can sign valid callbacks. Every user deploys their own via Step 2. (An older demo instance exists on Base **mainnet** at `0x39efE8A851A4Da22fa40828F6D4b3DC6b54545Aa`, but its oracle is a fixed key nobody else holds, so it is reference-only, not reusable.)
-- **The oracle wallet address must equal the contract's `oracle`.** The contract is deployed with `--constructor-args <USDC> <ORACLE_ADDRESS>`, where `ORACLE_ADDRESS = cast wallet address $ORACLE_PRIVATE_KEY`. The Compose task loads that same key via `evm.wallet({ privateKey: env.ORACLE_PRIVATE_KEY })`. If they don't match, every `approveTransfer`/`rejectTransfer` reverts with `not oracle`.
-- **Gas sponsorship:** the oracle wallet uses `sponsorGas: true` — it never needs native token for gas on sponsored chains (Base, Base Sepolia). The `ORACLE_PRIVATE_KEY` EOA needs **no gas for the deploy or at runtime** — not even deployment costs the oracle key anything, since `goldsky compose deployContract` deploys through the gas-sponsored Compose wallet, not the oracle key.
-- **`ORACLE_PRIVATE_KEY` is a real EOA private key.** Never print it, commit it, or log it. It is set once as a Compose secret and used locally only to derive its address (`cast wallet address $ORACLE_PRIVATE_KEY`) for the constructor arg — nowhere else.
+- **The oracle is the Compose smart wallet `compliance-oracle-wallet`.** Its address IS the contract's `oracle` constructor arg. Capture the address from `walletCreate({ appName: "<chosen app name>", walletName: "compliance-oracle-wallet" })` (in-app; `appName` is the chosen app name, `walletName` is explicit) or `goldsky compose wallet create compliance-oracle-wallet` (CLI), and pass it as the second constructor arg to `ComplianceGatedTransfer`. The Compose task loads the same wallet via `evm.wallet({ name: "compliance-oracle-wallet", sponsorGas: true })`. If they don't match, every `approveTransfer`/`rejectTransfer` reverts with `not oracle`. Gas is sponsored, no private key to manage.
+- **Gas sponsorship:** the oracle wallet uses `sponsorGas: true`, so it never needs native token for gas on sponsored chains (Base, Base Sepolia). `goldsky compose deployContract` deploys through the gas-sponsored Compose wallet, so neither the deploy nor the runtime callbacks cost the oracle anything.
 - **Do not import external packages in task code.** `evm`, `fetch`, `collection`, `env`, and `logger` all come from the injected `context` argument. The only import allowed in tasks is `compose` (for types) and sibling project files.
 - **Never run `goldsky compose deployContract`, `goldsky compose deploy`, `goldsky compose secret set`, `git push`, or `gh repo create` without showing the exact command first and getting explicit confirmation.**
+
+## Advanced: bring your own oracle key (production)
+
+The default path uses a gas-sponsored Compose smart wallet (`compliance-oracle-wallet`) with no key to manage. If you need your own key custody (for example, a production signer you control), you can bring your own EOA private key instead:
+
+- Set `ORACLE_PRIVATE_KEY` as a Compose secret: `goldsky compose secret set ORACLE_PRIVATE_KEY --value <key>`. Never print, commit, or log this key.
+- In `compose.yaml`, add `ORACLE_PRIVATE_KEY` to the `secrets:` block and set `api_version: "internal-pk-sponsored-otel"` (the internal channel is required for BYO-private-key combined with `sponsorGas`).
+- In the task source, load the wallet with `evm.wallet({ privateKey: env.ORACLE_PRIVATE_KEY, sponsorGas: true })` instead of the named `compliance-oracle-wallet`.
+- The contract's `oracle` constructor arg is `cast wallet address $ORACLE_PRIVATE_KEY`.
+
+This is not the default; most users should use the Compose smart wallet.
 
 ## The app (full source)
 
@@ -47,10 +57,9 @@ This is the complete compliance app. Scaffold these files verbatim (Step 0b writ
 
 ```yaml
 name: "compliance-oracle"
-api_version: "internal-pk-sponsored-otel"
+api_version: "stable"
 
 secrets:
-  - ORACLE_PRIVATE_KEY
   - WEBACY_API_KEY
 
 tasks:
@@ -73,8 +82,6 @@ tasks:
       - type: cron
         expression: "*/5 * * * *"
 ```
-
-> **`api_version: "internal-pk-sponsored-otel"`** pins an internal image channel that skips version-compatibility checks — required today for BYO-private-key (`ORACLE_PRIVATE_KEY`) combined with `sponsorGas`, so it's deliberate, not a typo.
 
 ### `tsconfig.json`
 
@@ -371,7 +378,7 @@ export async function main(ctx: TaskContext, payload: OnchainEvent) {
 
   // --- Step 3: Call back to the escrow contract ---
 
-  const wallet = await evm.wallet({ privateKey: env.ORACLE_PRIVATE_KEY, sponsorGas: true });
+  const wallet = await evm.wallet({ name: "compliance-oracle-wallet", sponsorGas: true });
 
   let txHash: string;
   let decision: "approved" | "rejected";
@@ -444,8 +451,8 @@ import { CONFIG } from "../lib/constants";
 export async function main(ctx: TaskContext) {
   const { evm } = ctx;
 
-  // Use the oracle private key for read calls (address must match the contract's oracle)
-  const wallet = await evm.wallet({ privateKey: ctx.env.ORACLE_PRIVATE_KEY });
+  // Use the oracle wallet for read calls (address must match the contract's oracle)
+  const wallet = await evm.wallet({ name: "compliance-oracle-wallet", sponsorGas: true });
 
   // Read how many transfers exist on the contract
   const totalTransfers = await wallet.readContract<bigint>(
@@ -504,7 +511,7 @@ libs = ["lib"]
 
 ---
 
-> **The steps below are the Bash / local-CLI procedure. If a `deployComposeApp` tool is available (webapp chatbot), do NOT follow them — this example is CLI-driven; see Mode Detection above.**
+> **The steps below are the Bash / local-CLI procedure. If a `deployComposeApp` tool is available (webapp chatbot), follow the in-app flow in Mode Detection above instead.**
 
 ## Step 0b — Scaffold the project
 
@@ -541,62 +548,48 @@ Per the golden rules in `/compose`, ask only what you can't derive, one question
 1. **"What should the app be called? (suggest `compliance-oracle`)"** — ask FIRST, before any wallet or contract step. The name is hard to change later: it scopes named wallets and participates in the CREATE2 salt for every `deployContract` (Step 2), so it must be settled now. Accept the default `compliance-oracle` on a shrug, and set it as the top-level `name:` in `compose.yaml`.
 2. **"Which chain?"** — **Base Sepolia (recommended)** — free, gas-sponsored, and you mint your own test USDC. Base mainnet is production (real USDC, real screening, real funds). Use the camelCase form in TS (`baseSepolia`) and snake_case in `compose.yaml` (`base_sepolia`).
 3. **"What risk threshold?"** — Webacy `overallRisk` is 0-100; senders scoring at or above the threshold are rejected. Default `50`. Set `RISK_THRESHOLD` in `src/lib/constants.ts`.
-4. **Recipient** — approved funds go to the **oracle (business) wallet** itself (the contract sends escrow to `oracle` on approval). That's the `oracle` set at construction — the `ORACLE_PRIVATE_KEY` EOA, not the Compose wallet that performs the deploy. No separate recipient to configure.
+4. **Recipient.** Approved funds go to the **oracle (business) wallet** itself (the contract sends escrow to `oracle` on approval). That's the `compliance-oracle-wallet` Compose smart wallet set at construction. No separate recipient to configure.
 
 ## Step 2 — Oracle wallet and contract deploy
 
-The oracle wallet is a plain EOA private key. Its address becomes the contract's `oracle`, and the same key signs the Compose callbacks at runtime (sponsored). `goldsky compose deployContract` deploys *through the gas-sponsored Compose wallet*, not the oracle key — so the oracle EOA needs no gas for the deploy. Have the user provide `ORACLE_PRIVATE_KEY`, or generate one. **Never print `ORACLE_PRIVATE_KEY`** — generate it straight into a chmod-600 `.env` and show only the derived address:
+The oracle is a named Compose smart wallet, `compliance-oracle-wallet`. Its address becomes the contract's `oracle`, and the Compose task signs callbacks through the same wallet at runtime (gas-sponsored). Create it first, capture its address, then deploy the contracts with that address as the `oracle` constructor arg. `goldsky compose deployContract` deploys through the gas-sponsored Compose wallet, so no funded EOA is needed for the deploy.
 
 ```bash
-# Generate the oracle key WITHOUT printing it: the JSON (which contains the key)
-# goes to a temp file, the key is extracted into a chmod-600 .env, and only the
-# derived address is ever echoed.
-cast wallet new --json > /tmp/k.json
-ORACLE_PRIVATE_KEY=$(jq -r '.[0].private_key' /tmp/k.json)
-touch .env && chmod 600 .env
-printf 'ORACLE_PRIVATE_KEY=%s\n' "$ORACLE_PRIVATE_KEY" >> .env
-ORACLE_ADDRESS=$(cast wallet address "$ORACLE_PRIVATE_KEY")
-echo "Oracle address: $ORACLE_ADDRESS"   # the ONLY thing ever printed
-shred -u /tmp/k.json
+# Create the oracle smart wallet and capture its address
+goldsky compose wallet create compliance-oracle-wallet
+# → capture the printed address as $ORACLE_ADDRESS
 ```
 
-Also add the RPC URL and Webacy key to `.env` (never commit this file):
-
-```env
-RPC_URL=https://sepolia.base.org   # or https://mainnet.base.org for production; used by the cast alternative in Step 7
-WEBACY_API_KEY=your_webacy_api_key
-```
-
-`ORACLE_ADDRESS` is already set if you ran the block above; in a fresh shell, re-derive it from `.env` — it is the `oracle` constructor arg, and the contract's `approveTransfer`/`rejectTransfer` must be signed by this same key at runtime:
+In a fresh shell, list the wallet to recover the address (it must match the contract's `oracle` at runtime):
 
 ```bash
-source .env
-ORACLE_ADDRESS=$(cast wallet address "$ORACLE_PRIVATE_KEY")
+goldsky compose wallet list
+# → copy the compliance-oracle-wallet address as $ORACLE_ADDRESS
 ```
 
-**Base Sepolia (recommended): deploy a MockUSDC first**, then use its address as the escrow's `_usdc` arg. Both deploys go through the gas-sponsored Compose wallet (Base Sepolia is sponsored, so nothing needs funding) — `deployContract` only changes who deploys; the `oracle` is still the `ORACLE_PRIVATE_KEY` EOA above. (Each `deployContract`/`writeContract` needs a project API key — pass `-t <key>` or have an active `goldsky login` session; generate the key at **Settings > API Keys** in the Goldsky dashboard.)
+**Base Sepolia (recommended): deploy a MockUSDC first**, then use its address as the escrow's `_usdc` arg. Both deploys go through the gas-sponsored Compose wallet (Base Sepolia is sponsored, so nothing needs funding). The `oracle` is the `compliance-oracle-wallet` address captured above. (Each `deployContract`/`writeContract` needs a project API key; pass `-t <key>` or have an active `goldsky login` session; generate the key at **Settings > API Keys** in the Goldsky dashboard.)
 
 ```bash
-# 1) MockUSDC — no constructor args
+# 1) MockUSDC - no constructor args
 goldsky compose deployContract contracts/MockUSDC.sol --chain-id 84532
 # capture the printed address as $USDC_ADDRESS
 
-# 2) ComplianceGatedTransfer(usdc, oracle) — oracle is the ORACLE_PRIVATE_KEY EOA
+# 2) ComplianceGatedTransfer(usdc, oracle) - oracle is the compliance-oracle-wallet address
 goldsky compose deployContract contracts/ComplianceGatedTransfer.sol \
   --chain-id 84532 \
   --constructor-args $USDC_ADDRESS $ORACLE_ADDRESS
 # capture the printed address as $CONTRACT_ADDRESS
 ```
 
-The ABI for each contract is auto-saved to `src/contracts/<Name>.json`. Once both deploys print `Address:`, generate the typed contract classes (required before any typecheck — the `tsconfig.json` `paths` entry points at `.compose/types.d.ts`, which codegen produces):
+The ABI for each contract is auto-saved to `src/contracts/<Name>.json`. Once both deploys print `Address:`, generate the typed contract classes (required before any typecheck; the `tsconfig.json` `paths` entry points at `.compose/types.d.ts`, which codegen produces):
 
 ```bash
 goldsky compose codegen
 ```
 
-> **TypeScript pin:** the inlined `tsconfig.json` typechecks on **TypeScript 5.x** — TS 6 rejects `baseUrl`. If you run a typecheck, pin `npx -y typescript@5 tsc` rather than a bare `tsc`.
+> **TypeScript pin:** the inlined `tsconfig.json` typechecks on **TypeScript 5.x**; TS 6 rejects `baseUrl`. If you run a typecheck, pin `npx -y typescript@5 tsc` rather than a bare `tsc`.
 
-**Base mainnet (production):** skip MockUSDC — pass native USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` straight in as `$USDC_ADDRESS`:
+**Base mainnet (production):** skip MockUSDC; pass native USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` straight in as `$USDC_ADDRESS`:
 
 ```bash
 goldsky compose deployContract contracts/ComplianceGatedTransfer.sol \
@@ -605,7 +598,6 @@ goldsky compose deployContract contracts/ComplianceGatedTransfer.sol \
 ```
 
 Capture `$CONTRACT_ADDRESS` and `$USDC_ADDRESS` for the next step, then run `goldsky compose codegen` here too.
-
 ## Step 3 — Wire the contract address and chain into the app
 
 Two files reference the chain/addresses. Use grep anchors — line numbers shift.
@@ -623,17 +615,7 @@ The event signature `TransferRequested(uint256,address,uint256)` stays as-is —
 
 Note: `src/lib/webacy.ts` hardcodes `?chain=base` in its Webacy request deliberately — testnet screening reuses mainnet reputation data, so leave it `base` even on Base Sepolia (the source comment doesn't say so).
 
-## Step 4 — Set Compose secrets
-
-The running app needs the oracle key (to sign callbacks) and the Webacy key (to screen). If you haven't already, now's the one thing only you can do — sign up at https://developers.webacy.co/ and create an API key; park it until here. (The whole flow through Step 3 was verified working with a stub key, so a placeholder is fine right up to this point.)
-
-```bash
-source .env
-goldsky compose secret set ORACLE_PRIVATE_KEY --value "$ORACLE_PRIVATE_KEY"
-goldsky compose secret set WEBACY_API_KEY --value "$WEBACY_API_KEY"
-```
-
-## Step 5 — Optional: publish to a new GitHub repo
+## Step 4 — Optional: publish to a new GitHub repo
 
 ```bash
 git init
@@ -646,7 +628,14 @@ else
 fi
 ```
 
-(The `.gitignore` from Step 0b excludes `.env`; the grep is a backstop — never commit the oracle key.)
+(The `.gitignore` from Step 0b excludes `.env`; the grep is a backstop. On the default keyless path there is no oracle key to leak; on the Advanced BYO-key path above, never commit `ORACLE_PRIVATE_KEY` or any private key.)
+
+## Step 5 — Set your secret (before deploy)
+
+The running task uses `WEBACY_API_KEY` to screen sender wallets via the Webacy AML API. If you haven't already, sign up at https://developers.webacy.co/ and create an API key. (The whole flow was verified working with a stub key set here before deploy, so a placeholder is fine right up to the smoke test.)
+
+- **CLI:** set the secret BEFORE `goldsky compose deploy` (Step 6): `goldsky compose secret set WEBACY_API_KEY --value <your_webacy_api_key>`. `compose deploy` validates that every manifest-declared secret exists and bakes it into the pod at deploy time, so an unset secret 400s the deploy with "The following secrets referenced in the manifest do not exist". Secrets are not hot-reloaded: setting or updating a secret after deploy only writes to storage and does NOT reach the running pod without a redeploy.
+- **In-app (chatbot):** the in-app deploy skips secret validation, so `deployComposeApp` (Step 6) succeeds without it. After deploy, add `WEBACY_API_KEY` in the Compose app's dashboard under the app's **Secrets** page, then **redeploy from the dashboard** so the pod picks it up. The app does not start working on set alone; the redeploy is required. NEVER attempt to set a secret from chat; there is no tool, by design.
 
 ## Step 6 — Deploy to Goldsky
 
@@ -658,7 +647,9 @@ First deploy may take 1-2 minutes. Watch for `Deployed compose app: <the chosen 
 
 ## Step 7 — Smoke test
 
-This step runs **after** `compose deploy` (Step 6), so the app's wallets now exist. The **primary** path drives the whole flow from the app's gas-sponsored default smart wallet via `writeContract` — no funded EOA needed. (A `cast` alternative with your own EOA follows.)
+This step runs **after** `compose deploy` (Step 6), so the app's wallets now exist. The **primary** path drives the whole flow from the app's gas-sponsored default smart wallet via `writeContract`, so no funded EOA is needed. (A `cast` alternative with your own EOA follows.)
+
+For the `cast` verification and alternative below, set `RPC_URL=https://sepolia.base.org` (or `https://mainnet.base.org` for production).
 
 **Primary — sponsored `writeContract` from the app wallet.** List the app's wallets and grab the default smart wallet as the sender:
 
@@ -683,7 +674,7 @@ goldsky compose writeContract --chain-id 84532 --to $CONTRACT_ADDRESS \
   --function "requestTransfer(uint256)" --args 1000000
 ```
 
-> **Why this works without the oracle key:** `MockUSDC.mint` is open; both `approve` and `requestTransfer` are sent from the same app wallet, and `requestTransfer` pulls via `transferFrom` from `msg.sender` — so the sender does not need to be the oracle. The oracle key only signs the `approveTransfer`/`rejectTransfer` callback at runtime.
+> **Why this works without the oracle wallet:** `MockUSDC.mint` is open; both `approve` and `requestTransfer` are sent from the same app wallet, and `requestTransfer` pulls via `transferFrom` from `msg.sender`, so the sender does not need to be the oracle. The oracle wallet only signs the `approveTransfer`/`rejectTransfer` callback at runtime.
 
 Then **stream** the logs and watch the decision land (bare `goldsky compose logs` is a one-shot dump; add `-f`/`--follow` to watch the next fire):
 
@@ -710,25 +701,24 @@ cast send $CONTRACT_ADDRESS "requestTransfer(uint256)" 1000000 \
   --rpc-url $RPC_URL --private-key $SENDER_KEY
 ```
 
-Generate `$SENDER_KEY` the same no-echo way as the oracle key (never print it): `cast wallet new --json > /tmp/s.json; SENDER_KEY=$(jq -r '.[0].private_key' /tmp/s.json); SENDER_ADDRESS=$(cast wallet address "$SENDER_KEY"); echo "$SENDER_ADDRESS"; shred -u /tmp/s.json`.
+Generate `$SENDER_KEY` without printing it (a separate funded EOA, not the oracle wallet): `cast wallet new --json > /tmp/s.json; SENDER_KEY=$(jq -r '.[0].private_key' /tmp/s.json); SENDER_ADDRESS=$(cast wallet address "$SENDER_KEY"); echo "$SENDER_ADDRESS"; shred -u /tmp/s.json`.
 
 ## Troubleshooting
 
 - **`error: Unknown command "deployContract". Did you mean command "deploy"?` (or the `writeContract` variant).** Compose CLI is older than 0.8.1. Run `goldsky compose update` (or `goldsky compose update 0.8.1`), confirm `goldsky compose --version` prints `0.8.1`+, then retry.
 - **Edits to `compose.yaml` or source files don't take effect after redeploy.** Stale `.compose/` bundle cache. Run `rm -rf .compose/` and redeploy.
-- **`approveTransfer`/`rejectTransfer` reverts with `not oracle`.** The Compose wallet's address doesn't match the contract's `oracle`. They must derive from the same `ORACLE_PRIVATE_KEY`. Check: `cast call $CONTRACT_ADDRESS "oracle()(address)" --rpc-url $RPC_URL` should equal `cast wallet address $ORACLE_PRIVATE_KEY`.
+- **`approveTransfer`/`rejectTransfer` reverts with `not oracle`.** The `compliance-oracle-wallet` address doesn't match the contract's `oracle`. They must be the same wallet. Check: `cast call $CONTRACT_ADDRESS "oracle()(address)" --rpc-url $RPC_URL` should equal the `compliance-oracle-wallet` address (from `goldsky compose wallet list`).
 - **`requestTransfer` reverts with "transfer amount exceeds allowance".** The sender didn't `approve` the escrow to spend their USDC first. Run the `approve` call before `requestTransfer`.
 - **Task never fires when a transfer is requested.** Confirm `compose.yaml`'s `contract:` and `network:` match where you deployed, the deploy succeeded, and the trigger is active (`goldsky compose status`). Wiring only one of `chain` (constants.ts) / `network` (compose.yaml) is the usual cause.
 - **Webacy returns an empty response / task throws.** Check `WEBACY_API_KEY` is set as a secret and valid, and the address is well-formed hex. Transient failures are absorbed by the `retry_config` (3 attempts, backoff).
 - **Reject scenario approves instead.** On Base Sepolia, a fresh test wallet has no on-chain history, so Webacy scores it low (it passes). Use a known-flagged address, or test the reject path on mainnet where real risk data exists.
-- **`insufficient funds for gas` on deploy.** On Base / Base Sepolia the deploy is sponsored. On other chains, fund the **Compose wallet** (the deployer — not the oracle key) with native gas; the `ORACLE_PRIVATE_KEY` EOA needs nothing.
+- **`insufficient funds for gas` on deploy.** On Base / Base Sepolia the deploy is sponsored. On other chains, fund the **Compose wallet** (the deployer) with native gas; the oracle wallet needs nothing.
 - **Re-running `deployContract` with identical contract + args + app is refused ("This contract has already been deployed with this app...").** This is a CREATE2 pre-tx refusal — it prints **no** `Deploy Block:`. The address is deterministic from contract code + constructor args + app name + project, so an identical combination reproduces the same address. Fresh-deploy levers: change a constructor arg, change the source, or use a different app name. For the no-arg `MockUSDC` the **only** lever is the app name; for `ComplianceGatedTransfer` (takes `(usdc, oracle)`) changing a constructor arg also works. ⚠ Renaming the app changes **all** future deploy addresses and conflicts with the `compose deploy` app name, so prefer the constructor-arg lever where possible — for no-arg contracts the app-name lever is the only option.
 
 ## What you should NOT do
 
 - Do not point the app at the mainnet demo contract `0x39efE8A851A4Da22fa40828F6D4b3DC6b54545Aa` (or any contract you didn't deploy). Its `oracle` is a fixed key you don't hold, so every callback reverts `not oracle`. Deploy your own.
-- Do not use a different key for the contract's `oracle` constructor arg than the one in `ORACLE_PRIVATE_KEY`. They must be the same EOA.
-- Do not commit or log `ORACLE_PRIVATE_KEY`. It is a real signing key.
+- Do not use a different address for the contract's `oracle` constructor arg than the `compliance-oracle-wallet` address. They must be the same wallet.
 - Do not import `viem`, `ethers`, or any external package inside the Compose task code — use `evm.decodeEventLog`, `evm.wallet`, and `evm.chains` from the context.
 - Do not deploy the gated-transfer contract to Base mainnet with real USDC as a first test — start on Base Sepolia with MockUSDC.
 

--- a/skills/compose-dividend-distribution/SKILL.md
+++ b/skills/compose-dividend-distribution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-dividend-distribution
-description: "Build and deploy the Goldsky Compose corporate-actions / dividend-distribution example under the user's own account — a durable, idempotent distributor that pays N token holders pro-rata for a tokenized corporate action (dividend, coupon, rebate, airdrop) with an on-chain audit trail. The interesting bit: Compose orchestrates a Goldsky Turbo job-mode pipeline as an ephemeral subroutine — declaring a campaign spawns a one-shot pipeline that snapshots share-token holders at a record block, waits for it, pays each holder via a gas-sponsored wallet, then deletes the pipeline. Triggers on: 'dividend distribution', 'pay dividends onchain', 'distribute dividends to shareholders', 'corporate actions distributor', 'pro-rata payout to token holders', 'airdrop pro-rata by balance', 'cap table distribution', 'set up / deploy the dividend / corporate-actions example'. Ships pointed at shared permissionless demo contracts on Base Sepolia so there's nothing to deploy. NOTE: this example is CLI-driven — it needs a project-API-key secret and spawns Turbo pipelines at runtime, so it cannot be deployed through the in-app deployComposeApp card. For a custom/novel Compose app, use /compose. For debugging a deployed app, use /compose-doctor. For manifest/CLI/API field lookups, use /compose-reference."
+description: "Build and deploy the Goldsky Compose corporate-actions / dividend-distribution example under the user's own account — a durable, idempotent distributor that pays N token holders pro-rata for a tokenized corporate action (dividend, coupon, rebate, airdrop) with an on-chain audit trail. The interesting bit: Compose orchestrates a Goldsky Turbo job-mode pipeline as an ephemeral subroutine — declaring a campaign spawns a one-shot pipeline that snapshots share-token holders at a record block, waits for it, pays each holder via a gas-sponsored wallet, then deletes the pipeline. Triggers on: 'dividend distribution', 'pay dividends onchain', 'distribute dividends to shareholders', 'corporate actions distributor', 'pro-rata payout to token holders', 'airdrop pro-rata by balance', 'cap table distribution', 'set up / deploy the dividend / corporate-actions example'. Ships pointed at shared permissionless demo contracts on Base Sepolia so there's nothing to deploy. Deploys fully in-app or via the CLI; the only runtime requirement is a `GOLDSKY_PROJECT_KEY` secret, set as the last step. For a custom/novel Compose app, use /compose. For debugging a deployed app, use /compose-doctor. For manifest/CLI/API field lookups, use /compose-reference."
 ---
 
 # Build: Compose dividend distribution (corporate-actions)
@@ -24,7 +24,7 @@ This template deliberately omits those rules and that reference — they are **r
 
 Pick the mode from the tools available to you:
 
-- **A `deployComposeApp` tool is available (Goldsky webapp chatbot).** This example **cannot be deployed through the in-app deploy card**, and that is expected — say so plainly. Two hard reasons: (1) it requires a project-API-key secret (`GOLDSKY_PROJECT_KEY`) that only the `goldsky` CLI / dashboard can set, and (2) at runtime it spawns, polls, and deletes **job-mode Turbo pipelines**, which the in-app single-app deploy path does not provision. So do NOT scaffold files or call `deployComposeApp`. Instead: give a 3-4 sentence explanation of what the app does and why it's CLI-driven, then walk the user through the CLI steps below (or tell them to run this skill locally with `npx skills add goldsky-io/goldsky-agent` where a `Bash` tool is available). Everything from Step 0 down is that CLI procedure.
+- **A `deployComposeApp` tool is available (Goldsky webapp chatbot).** This example deploys fully in-app. The job-mode Turbo pipeline is spawned at runtime via the Turbo API (an in-app `ctx.fetch` POST in `src/lib/turbo.ts`), not provisioned at deploy, so `deployComposeApp` deploys the app fine. In-app flow: run the Step 0b app-name interview first (the app name is the FIRST question), then scaffold these files in-memory from **The app (full source)** below and pass them to `deployComposeApp`: `compose.yaml`, `src/tasks/declare-campaign.ts`, `src/lib/constants.ts`, `src/lib/types.ts`, `src/lib/math.ts`, `src/lib/normalize.ts`, `src/lib/db.ts`, `src/lib/driver.ts`, and `src/lib/turbo.ts`. On the recommended shared-contract path there is nothing to deploy, so exclude the three `contracts/*.sol` sources (the shared path deploys nothing); on the deploy-your-own path also scaffold the `.sol` files and use `deployContract` for MockUSDC, ShareToken (passing the holder/amount arrays), and DistributionCampaign. Wire the four contract CONFIG values in `src/lib/constants.ts` (the three deployed addresses plus `shareTokenDeployBlock`), then call `deployComposeApp`. The `GOLDSKY_PROJECT_KEY` secret is the user's LAST step: the in-app deploy skips secret validation, so `deployComposeApp` succeeds without it, but the app won't run until the user adds the secret in the Compose app's dashboard **and redeploys from the dashboard** so the pod picks it up (secrets are baked into the pod at deploy, not hot-reloaded). NEVER attempt to set a secret from chat; there is no tool, by design. Note: the chatbot has no `writeContract` tool, so it cannot mint test MockUSDC to the `corp-actions-operator` wallet; before declaring a campaign the user must run the Step 4 mint via the CLI (`goldsky compose writeContract`) or the dashboard (the task does the USDC `approve` itself at declare time, but the operator wallet must hold the USDC first).
 - **`Bash` is available (local CLI / coding agent):** execute the steps below directly, parse output, and substitute captured values into later commands.
 - **Neither (pure reference Q&A):** explain what the app does and the lifecycle; only if asked for step-by-step help, output one command at a time and have the user paste output back. Point them at `npx skills add goldsky-io/goldsky-agent` to run it locally with Bash.
 
@@ -37,9 +37,9 @@ Pick the mode from the tools available to you:
 - **Resumable by design — never worry about double-pay.** Re-POSTing the same `campaignId` drives the existing campaign forward. A per-holder on-chain `isPaid()` check plus the contract's `require(!paid[id][holder])` guard mean Compose can crash/restart at any point with zero risk of double-paying.
 - **This example does not run in a local/dev Compose cluster without Turbo pipeline infra.** It deploys against real Goldsky (app.goldsky.com), which is where a user runs it anyway.
 
-## The manifest and demo config
+## The app (full source)
 
-The app itself is a single HTTP task plus a small TypeScript library and three Solidity contracts. It is large enough that the CLI flow **scaffolds it from `goldsky-io/documentation-examples` via `degit` (Step 0b)** rather than writing every file by hand — only edit files when customizing. The two pieces worth seeing inline:
+This is the complete dividend app. Scaffold these files verbatim (Step 0b writes them to disk via `degit`; the in-app flow scaffolds them in-memory from the blocks below). The shared Base Sepolia demo contracts in `src/lib/constants.ts` mean the recommended path has nothing to deploy. Only edit `src/lib/constants.ts` to wire in your own contract addresses (Step 1 Branch B) or swap to Base mainnet.
 
 ### `compose.yaml`
 
@@ -54,7 +54,8 @@ api_version: "stable"
 # snapshots back into that DB.
 secrets:
   # Project API key used to spawn / poll / delete Turbo pipelines from
-  # inside declare_campaign. Set once: goldsky compose secret set GOLDSKY_PROJECT_KEY --value <key>
+  # inside declare_campaign. Set once:
+  #   goldsky secret create GOLDSKY_PROJECT_KEY <key>
   - GOLDSKY_PROJECT_KEY
 
 tasks:
@@ -69,22 +70,1490 @@ tasks:
       backoff_factor: 1
 ```
 
-### Shared demo contracts — `src/lib/constants.ts` (`CONFIG`)
+### `src/tasks/declare-campaign.ts`
 
-The repo ships pointed at these permissionless Base Sepolia contracts. On the no-deploy path, leave them as-is:
+```typescript
+import type { TaskContext } from "compose";
+import { encodePacked, keccak256 } from "viem";
 
-```ts
-export const CONFIG = {
-  chain:      "baseSepolia" as const,   // evm.chains[chain] key (camelCase)
-  turboChain: "base_sepolia",           // Turbo dataset prefix (snake_case)
-  shareToken:       "0x713e0749a9Fe480322990913850e81b0F4F4dc0d", // 25 seed holders pre-minted
-  payToken:         "0x8ec24F07F08745fc3D979336AA81d4Dc73f3D9DE", // MockUSDC (permissionless mint)
-  campaignContract: "0xA8e58573B1e10908b63d12B603aCF9C784BF904E", // permissionless: anyone can declare()
-  shareTokenDeployBlock: 42275958,      // lower bound for the snapshot pipeline's block-range filter
-};
+import { CONFIG } from "../lib/constants";
+import { driveCampaign } from "../lib/driver";
+import { isHexBytes32 } from "../lib/normalize";
+import { createSnapshotPipeline } from "../lib/turbo";
+import type { Campaign, DeclareParams, Hex } from "../lib/types";
+
+/**
+ * HTTP trigger.
+ *
+ *   POST {
+ *     "campaignId":  "0x<32 bytes hex>",  // operator-supplied id, unique per operator
+ *     "recordBlock": 24500000,            // snapshot point; must be <= chain head
+ *     "totalAmount": "10000000000"        // 10,000 mUSDC (6 decimals)
+ *   }
+ *
+ *   1. Validate `recordBlock` is in the past (or current). Future-dated record
+ *      blocks aren't supported in this demo — they're a real corp-action feature
+ *      (record dates often look forward) but out of scope here.
+ *   2. Approve the campaign contract for `totalAmount` of MockUSDC.
+ *   3. Call `DistributionCampaign.declare(...)` — pulls escrow atomically.
+ *   4. Spawn a job-mode Turbo pipeline to snapshot holders of `shareToken`
+ *      from the share-token deploy block up to `recordBlock`. Per-campaign
+ *      sink tables avoid cross-campaign aggregate contamination.
+ *   5. Drive the campaign through snapshot → paying → complete inline,
+ *      polling the pipeline at STATE_POLL_INTERVAL_MS until done. The
+ *      whole lifecycle finishes in this single HTTP request.
+ *
+ * Idempotent on `campaignId`: a second POST with the same id resumes the
+ * existing campaign (drives it forward if non-terminal) instead of
+ * re-declaring.
+ */
+export async function main(context: TaskContext, params?: DeclareParams) {
+  const { evm, collection } = context;
+  if (!params) throw new Error("POST body required");
+
+  const userId = params.campaignId;
+  if (!isHexBytes32(userId)) {
+    throw new Error("campaignId must be a 0x-prefixed 32-byte hex string");
+  }
+  if (typeof params.recordBlock !== "number" || params.recordBlock <= 0) {
+    throw new Error("recordBlock must be a positive integer");
+  }
+  const totalAmount = BigInt(params.totalAmount);
+  if (totalAmount <= 0n) throw new Error("totalAmount must be positive");
+
+  const campaigns = await collection<Campaign>("campaigns", [
+    { path: "status", type: "text" },
+  ]);
+
+  const rowId = userId.toLowerCase();
+  const existing = await campaigns.getById(rowId);
+  if (existing) {
+    // Resume an in-flight campaign — keep driving it forward. Terminal
+    // states (complete/failed) just return without doing anything.
+    await driveCampaign(context, campaigns, existing);
+    const fresh = (await campaigns.getById(rowId)) ?? existing;
+    return responseFor(fresh, "resumed");
+  }
+
+  // --- recordBlock <= currentBlock ---
+  // Resolved against the chain's public RPC via context.fetch (only fetch
+  // path that's --allow-net'd in this child process).
+  const chain = evm.chains[CONFIG.chain];
+  const currentBlock = await getCurrentBlock(context, chain.rpcUrls.default.http[0]);
+  const recordBlock = BigInt(params.recordBlock);
+  if (recordBlock > currentBlock) {
+    throw new Error(
+      `recordBlock ${recordBlock} > currentBlock ${currentBlock}; ` +
+        `future-dated record blocks are out of scope for this demo`,
+    );
+  }
+
+  const wallet = await evm.wallet({
+    name: "corp-actions-operator",
+    sponsorGas: true,
+  });
+
+  // --- approve + declare on-chain ---
+  await wallet.writeContract(
+    chain,
+    CONFIG.payToken,
+    "approve(address,uint256)",
+    [CONFIG.campaignContract, totalAmount.toString()],
+  );
+
+  const { hash } = await wallet.writeContract(
+    chain,
+    CONFIG.campaignContract,
+    "declare(bytes32,address,address,uint256)",
+    [userId, CONFIG.payToken, CONFIG.shareToken, totalAmount.toString()],
+  );
+
+  // canonicalId matches the contract's keccak256(operator, userId).
+  const onChainId = keccak256(
+    encodePacked(["address", "bytes32"], [wallet.address, userId as Hex]),
+  );
+
+  // --- spawn the snapshot pipeline ---
+  // If this fails AFTER declare(), the operator can recover escrow with
+  // DistributionCampaign.seal(). The campaign row is not written, so
+  // there's nothing to drive forward.
+  const pipeline = await createSnapshotPipeline(context, {
+    campaignId: userId,
+    shareToken: CONFIG.shareToken,
+    recordBlock,
+  });
+
+  const campaign: Campaign = {
+    rowId,
+    userId: rowId as Hex,
+    onChainId,
+    shareToken: CONFIG.shareToken,
+    payToken: CONFIG.payToken,
+    totalAmount: totalAmount.toString(),
+    recordBlock: recordBlock.toString(),
+    declareTxHash: hash as Hex,
+    pipelineName: pipeline.name,
+    status: "snapshotting",
+    createdAt: Date.now(),
+  };
+  await campaigns.setById(rowId, campaign);
+
+  // Drive the campaign through snapshot → paying → complete inline. If
+  // anything throws, the partial state is preserved and the operator can
+  // re-POST the same campaignId to resume. Re-throw to surface failure.
+  await driveCampaign(context, campaigns, campaign);
+  const final = (await campaigns.getById(rowId)) ?? campaign;
+  return responseFor(final, "declared");
+}
+
+function responseFor(c: Campaign, source: "declared" | "resumed") {
+  return {
+    status: c.status,
+    source,
+    userId: c.userId,
+    onChainId: c.onChainId,
+    pipelineName: c.pipelineName,
+    declareTxHash: c.declareTxHash,
+    failureReason: c.status === "failed" ? c.failureReason : undefined,
+  };
+}
+
+async function getCurrentBlock(
+  ctx: TaskContext,
+  rpcUrl: string,
+): Promise<bigint> {
+  const res = await ctx.fetch<{ result?: string; error?: { message: string } }>(
+    rpcUrl,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] },
+    },
+  );
+  if (res?.error) throw new Error(`eth_blockNumber: ${res.error.message}`);
+  if (!res?.result) throw new Error("eth_blockNumber returned no result");
+  return BigInt(res.result);
+}
 ```
 
-Deploy-your-own (Step 1, Branch B) replaces these four values with the addresses and deploy block `goldsky compose deployContract` prints. The rest of the app (`src/lib/{types,normalize,math,db,turbo,driver}.ts`, `src/tasks/declare-campaign.ts`, `contracts/*.sol`) is scaffolded verbatim by `degit`; read those files in the cloned repo if the user wants to customize the payout math, the concurrency, or the pipeline shape.
+### `src/lib/constants.ts`
+
+```typescript
+import type { Hex } from "./types";
+
+/**
+ * Single-chain demo on Base Sepolia. Each declaration spawns its own
+ * job-mode Turbo pipeline, so there's nothing chain-specific to configure
+ * beyond the deployed contract addresses below.
+ *
+ * Defaults to Base Sepolia so the demo costs no real gas and uses the shared
+ * permissionless contracts below (open mint on MockUSDC, open declare() on the
+ * campaign). To run on Base mainnet instead, swap in these values (real gas
+ * applies):
+ *   chain: "base", turboChain: "base",
+ *   shareToken:        "0xE05Ceb3E269029E3bab46E35515e8987060D1027",
+ *   payToken (MockUSDC): "0x02D9Df62B7AED15739D638B92BAcEA2ce4Cb3d70",
+ *   campaignContract:  "0x81051f77ea167b631Dd7F40ac414A9F9344Fb162",
+ *   shareTokenDeployBlock: 45654954,
+ *
+ * Update after running `scripts/deploy.sh`.
+ */
+export const CONFIG = {
+  chain:      "baseSepolia" as const,   // evm.chains[chain] key (camelCase)
+  turboChain: "base_sepolia",           // Turbo dataset prefix (snake_case network slug)
+  shareToken:       "0x713e0749a9Fe480322990913850e81b0F4F4dc0d" as Hex,
+  payToken:         "0x8ec24F07F08745fc3D979336AA81d4Dc73f3D9DE" as Hex,  // MockUSDC (permissionless mint)
+  campaignContract: "0xA8e58573B1e10908b63d12B603aCF9C784BF904E" as Hex,  // permissionless: anyone can declare()
+  // Block at which `shareToken` was deployed. Job-mode forces
+  // `start_at: earliest`, so we can't anchor the source there directly;
+  // instead this is used as the lower bound in the snapshot pipeline's
+  // SQL filter (`block_number BETWEEN <deploy> AND <record>`), which lets
+  // the planner prune all pre-deploy blocks before scanning. Per Jeff: a
+  // filter-level block range is meaningfully faster than a source-level
+  // `end_block` alone.
+  shareTokenDeployBlock: 42275958,
+};
+
+/**
+ * Concurrent pay() calls. Bounded by the gas-sponsored bundler's throughput
+ * (~1-5 userOps/sec/sender). Set high enough that the demo's full
+ * 25-holder snapshot fires in a single batch.
+ */
+export const CONCURRENCY = 25;
+
+/**
+ * State-poll cadence while waiting for the Turbo job-mode snapshot to
+ * finish. With Jeff's filter-level block range the snapshot finishes in
+ * ~5-10s, so we poll fast (2s) so `declare_campaign` can drive the campaign
+ * end-to-end inline before returning.
+ */
+export const STATE_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Hard cap on snapshot-poll iterations per drive call. Set high so we wait
+ * out the snapshot in-line for any realistic case; pathological hangs still
+ * eventually fall through to the cron path.
+ */
+export const MAX_POLLS_PER_TICK = 100;  // 100 × 2s = ~3.3 minutes
+
+/**
+ * The Turbo pipeline writes into per-campaign tables to avoid cross-campaign
+ * SUM contamination in the `postgres_aggregate` sink.
+ *
+ *   share_balances_<id>      — agg table (account, balance)
+ *   share_transfer_log_<id>  — landing table (truncated per checkpoint)
+ *
+ * `id` is a 16-char slice of campaignId — stable, unique, fits in Postgres'
+ * 63-char identifier limit.
+ */
+export function pipelineId(campaignId: string): string {
+  return campaignId.toLowerCase().replace(/^0x/, "").slice(0, 16);
+}
+
+export function pipelineName(campaignId: string): string {
+  return `corp-actions-${pipelineId(campaignId)}`;
+}
+
+export function aggTableName(campaignId: string): string {
+  return `share_balances_${pipelineId(campaignId)}`;
+}
+```
+
+### `src/lib/types.ts`
+
+```typescript
+export type Hex = `0x${string}`;
+
+/**
+ * Campaign lifecycle:
+ *
+ *   snapshotting → paying → complete
+ *                  ↘ failed
+ *
+ *   - snapshotting: a job-mode Turbo pipeline is running, indexing Transfer
+ *     events of `shareToken` from chain genesis up to `recordBlock`.
+ *   - paying: the pipeline has emitted the snapshot to Postgres; the cron is
+ *     pro-rata paying out per holder.
+ *   - complete: every holder is paid on-chain. Pipeline has been deleted.
+ *   - failed: the pipeline errored. Pipeline has been deleted; the campaign
+ *     row stays around for postmortem (escrow can be recovered via
+ *     `DistributionCampaign.seal()`).
+ */
+export type CampaignStatus = "snapshotting" | "paying" | "complete" | "failed";
+
+export interface DeclareParams {
+  campaignId: string;   // bytes32 hex string — operator-supplied id
+  recordBlock: number;  // snapshot point; must be <= chain head at declare time
+  totalAmount: string;  // bigint as string (USDC has 6 decimals)
+}
+
+export interface Campaign {
+  rowId: string;            // = userId (lowercased) — collection unique key
+  userId: Hex;              // operator-supplied campaignId, lowercased
+  onChainId: Hex;           // keccak256(operator, userId)
+  shareToken: Hex;          // resolved server-side from constants
+  payToken: Hex;            // resolved server-side (MockUSDC)
+  totalAmount: string;
+  recordBlock: string;      // snapshot block, recorded both on-chain and here
+  declareTxHash: Hex;
+  pipelineName: string;     // unique per campaign; used for /state polls and DELETE
+  status: CampaignStatus;
+  createdAt: number;
+  snapshotCompletedAt?: number;
+  completedAt?: number;
+  failedAt?: number;
+  failureReason?: string;
+  // Persisted payouts so the holder/amount table survives terminalCleanup
+  // (which drops the per-campaign Postgres tables). Populated when the
+  // driver transitions to "paying" and the pro-rata is computed; bigints
+  // serialised as decimal strings so the row round-trips through JSON.
+  payouts?: PersistedPayout[];
+}
+
+export interface PersistedPayout {
+  holder: Hex;
+  sharesAtSnapshot: string;  // bigint as text
+  amount: string;            // bigint as text (USDC, 6 decimals)
+  payTxHash?: Hex;           // captured per-batch in drivePayouts
+}
+
+export interface Holder {
+  address: Hex;
+  balance: bigint;
+}
+
+export interface Payout {
+  holder: Hex;
+  amount: bigint;
+  sharesAtSnapshot: bigint;
+}
+```
+
+### `src/lib/math.ts`
+
+```typescript
+import type { Holder, Payout } from "./types";
+import { normalizeAddr } from "./normalize";
+
+/**
+ * Pro-rata payout calculator.
+ *
+ * Integer division floors each holder's share, leaving a remainder. To make the
+ * sum equal `totalAmount` exactly, the remainder is added to the LAST holder's
+ * payout. This rounding direction is documented and stable: holders are sorted
+ * by address ascending so "last" is deterministic across runs.
+ *
+ * @param holders     non-empty list of holders with bigint balances
+ * @param totalAmount total escrow to distribute (bigint)
+ * @param totalSupply sum of all holder balances (bigint)
+ */
+export function proRata(
+  holders: Holder[],
+  totalAmount: bigint,
+  totalSupply: bigint,
+): Payout[] {
+  if (holders.length === 0) return [];
+  if (totalSupply === 0n) {
+    throw new Error("totalSupply must be positive");
+  }
+
+  // Sort by address ascending so "last holder" is deterministic.
+  const sorted = [...holders].sort((a, b) =>
+    a.address.toLowerCase() < b.address.toLowerCase() ? -1 : 1,
+  );
+
+  const payouts: Payout[] = [];
+  let allocated = 0n;
+  for (let i = 0; i < sorted.length; i++) {
+    const h = sorted[i];
+    const isLast = i === sorted.length - 1;
+    const amount = isLast
+      ? totalAmount - allocated // last holder absorbs floor remainder
+      : (h.balance * totalAmount) / totalSupply;
+    payouts.push({
+      holder: normalizeAddr(h.address),
+      amount,
+      sharesAtSnapshot: h.balance,
+    });
+    allocated += amount;
+  }
+  return payouts;
+}
+```
+
+### `src/lib/normalize.ts`
+
+```typescript
+import type { Hex } from "./types";
+
+const BYTES32_RE = /^0x[a-fA-F0-9]{64}$/;
+const ADDR_RE = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Normalize an EVM address to lowercase 0x-hex.
+ * Apply at every boundary: Postgres reads, collection keys, contract args.
+ */
+export function normalizeAddr(s: string): Hex {
+  if (!ADDR_RE.test(s)) {
+    throw new Error(`invalid address: ${s}`);
+  }
+  return s.toLowerCase() as Hex;
+}
+
+export function isHexBytes32(s: string): boolean {
+  return BYTES32_RE.test(s);
+}
+```
+
+### `src/lib/db.ts`
+
+```typescript
+import type { TaskContext } from "compose";
+import type { Hex, Holder } from "./types";
+
+/**
+ * Query Neon's HTTP `/sql` endpoint via compose's IPC-routed `context.fetch`.
+ *
+ * Why not the `@neondatabase/serverless` driver?
+ *   The compose-task child process is compiled WITHOUT `--allow-net`. Raw TCP
+ *   AND `globalThis.fetch` from the task code both error with `EPERM`. The ONLY
+ *   permitted egress path is `context.fetch`, which IPCs into the host process
+ *   (which has `--allow-net`).
+ *
+ * `POSTGRES_CONNECTION_STRING` is auto-injected by compose-cloud. The Turbo
+ * job-mode pipelines that this app spawns write into the same Neon DB via
+ * the auto-created `CORPORATE_ACTIONS` project secret.
+ */
+
+interface NeonRow {
+  [key: string]: string | number | boolean | null;
+}
+interface NeonResponse {
+  rows?: NeonRow[];
+}
+
+function getConnectionString(): string {
+  const url = Deno.env.get("POSTGRES_CONNECTION_STRING");
+  if (!url) {
+    throw new Error("POSTGRES_CONNECTION_STRING not set");
+  }
+  // Tack on params that bust Neon pool stickiness:
+  //   - target_session_attrs=read-write → routes to primary, not a replica
+  //   - application_name=<unique>      → defeats pool slot stickiness so each
+  //                                      HTTP query gets a freshly-spawned
+  //                                      backend connection (which sees
+  //                                      committed writes, not a stale snapshot)
+  // We've measured ~145s read lag without these; with them the read should
+  // see writes within seconds.
+  const u = new URL(url);
+  u.searchParams.set("target_session_attrs", "read-write");
+  u.searchParams.set(
+    "application_name",
+    `corp-actions-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  return u.toString();
+}
+
+/** Derive Neon's HTTP `/sql` URL from a Postgres connection string. */
+function neonHttpUrl(connStr: string): string {
+  const u = new URL(connStr);
+  // Use hostname (not host) so we drop the :5432 postgres port; HTTPS goes
+  // to 443. Replace the first dotted segment with "api." per the official
+  // @neondatabase/serverless transformation.
+  const apiHost = u.hostname.replace(/^[^.]+\./, "api.");
+  return `https://${apiHost}/sql`;
+}
+
+export async function neonQuery(
+  ctx: TaskContext,
+  query: string,
+  params: unknown[] = [],
+): Promise<NeonRow[]> {
+  const connStr = getConnectionString();
+  const url = neonHttpUrl(connStr);
+  const res = await ctx.fetch<NeonResponse>(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Neon-Connection-String": connStr,
+      "Neon-Raw-Text-Output": "true",
+      "Neon-Array-Mode": "false",
+    },
+    body: { query, params },
+  });
+  return res?.rows ?? [];
+}
+
+/**
+ * Compute holder balances for a campaign's snapshot.
+ *
+ * Each campaign's pipeline writes raw Transfer rows to its own
+ * `share_balances_<id>` table (no in-pipeline aggregation — see the rant in
+ * `lib/turbo.ts` about FixedSizeBinary handling). The aggregate runs here
+ * as a Postgres SQL: every transfer credits the recipient and debits the
+ * sender (skipping the zero-address sender for mints), summed per account.
+ *
+ * Postgres handles binary→numeric coercion at write time — `amount` lands
+ * as `numeric(78,0)` which we can cast to text and parse as a JS bigint
+ * without precision loss.
+ */
+export async function getHolders(
+  ctx: TaskContext,
+  table: string,
+): Promise<Holder[]> {
+  // `table` is a constructed identifier from pipelineId() — alphanumeric +
+  // underscore only — so direct interpolation is safe. (Postgres prepared
+  // statements don't support parameterising table names anyway.)
+  const rows = await neonQuery(
+    ctx,
+    `SELECT account, SUM(delta)::text AS balance
+       FROM (
+         SELECT lower(recipient) AS account, amount AS delta
+           FROM "${table}"
+         UNION ALL
+         SELECT lower(sender) AS account, -amount AS delta
+           FROM "${table}"
+          WHERE lower(sender) != '0x0000000000000000000000000000000000000000'
+       ) ledger
+      GROUP BY account
+     HAVING SUM(delta) > 0
+      ORDER BY account ASC`,
+  );
+  return rows.map((r) => ({
+    address: String(r.account).toLowerCase() as Hex,
+    balance: BigInt(String(r.balance)),
+  }));
+}
+
+/**
+ * Number of Transfer rows in the per-campaign table, or `null` if the table
+ * doesn't exist yet.
+ *
+ * Why count rather than just check existence?
+ *   The Postgres sink creates the table on the very first checkpoint —
+ *   even an "empty epoch" with zero matching rows commits, which creates
+ *   the schema. So `aggTableExists` can return `true` while the pipeline
+ *   is still mid-scan and hasn't reached blocks where the share token's
+ *   Transfers live. Counting rows distinguishes "sink initialized" from
+ *   "sink has actually delivered data".
+ */
+export async function aggTableRowCount(
+  ctx: TaskContext,
+  aggTable: string,
+): Promise<number | null> {
+  // Beefy diagnostic version: schema-qualified count, planner-stat count,
+  // physical table size, schema list, and connection identity. Designed
+  // to triangulate a Neon read-after-write visibility lag we've been
+  // seeing where count(*) returns 0 for ~2 minutes after the pipeline
+  // commits ~10 rows.
+  try {
+    const diag = await neonQuery(
+      ctx,
+      `SELECT
+         (SELECT count(*)::text FROM public."${aggTable}") AS n_public,
+         (SELECT pg_table_size('public."${aggTable}"')::text) AS bytes,
+         pg_is_in_recovery()::text AS in_recovery,
+         pg_last_xact_replay_timestamp()::text AS last_replay,
+         now()::text AS now_ts,
+         (SELECT EXTRACT(epoch FROM (now() - pg_last_xact_replay_timestamp()))::text) AS replay_lag_s,
+         pg_backend_pid()::text AS pid,
+         (SELECT setting FROM pg_settings WHERE name = 'application_name') AS app_name`,
+    );
+    const r = diag[0] ?? {};
+    const n = Number(r.n_public ?? 0);
+    console.log(
+      `[db] "${aggTable}" n=${r.n_public} bytes=${r.bytes} ` +
+        `recovery=${r.in_recovery} replay_lag_s=${r.replay_lag_s} ` +
+        `last_replay=${r.last_replay} now=${r.now_ts} ` +
+        `pid=${r.pid} app=${r.app_name}`,
+    );
+    return n;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/does not exist|undefined.relation|relation .* does not exist/i.test(msg)) {
+      console.log(`[db] "${aggTable}" → table missing`);
+      return null;
+    }
+    console.log(`[db] "${aggTable}" threw: ${msg}`);
+    throw err;
+  }
+}
+
+/**
+ * Drop the per-campaign table. Called on terminal cleanup so the user's
+ * Neon DB doesn't accumulate orphaned tables across many campaigns.
+ *
+ * MUST be called AFTER the pipeline has been DELETE-ed — Turbo's sink writer
+ * holds a connection, and dropping while it's still active is racing.
+ */
+export async function dropCampaignTables(
+  ctx: TaskContext,
+  transfersTable: string,
+): Promise<void> {
+  await neonQuery(ctx, `DROP TABLE IF EXISTS "${transfersTable}"`);
+}
+```
+
+### `src/lib/driver.ts`
+
+```typescript
+import type { TaskContext } from "compose";
+
+import {
+  aggTableName,
+  CONCURRENCY,
+  CONFIG,
+  MAX_POLLS_PER_TICK,
+  STATE_POLL_INTERVAL_MS,
+} from "./constants";
+import { aggTableRowCount, dropCampaignTables, getHolders } from "./db";
+import { proRata } from "./math";
+import { deletePipeline, getPipelineState } from "./turbo";
+import type { Campaign, Payout, PersistedPayout } from "./types";
+
+/**
+ * Drive a single campaign through the snapshot → paying → complete state
+ * machine. Called inline by declare_campaign; can be called repeatedly to
+ * resume a stuck campaign.
+ *
+ *   - status="snapshotting": poll the campaign's job-mode pipeline state at
+ *     STATE_POLL_INTERVAL_MS up to MAX_POLLS_PER_TICK iterations until it
+ *     transitions to `completed` (or its k8s deployment auto-cleans up
+ *     after a successful run, which we infer from `unknown` + agg table
+ *     having rows). On `error` → flip to "failed", drop the per-campaign
+ *     tables, delete the pipeline.
+ *
+ *   - status="paying": read the snapshot from the per-campaign agg table,
+ *     compute pro-rata, pay each holder via DistributionCampaign.pay() with
+ *     bounded concurrency. The contract's `paid[id][holder]` mapping is the
+ *     sole source of truth for "did this holder get paid?" — re-read on
+ *     every drive call, so a pod kill mid-batch is recovered cleanly.
+ *     When `escrowRemaining == 0` → mark complete, delete pipeline,
+ *     drop tables.
+ *
+ *   - status="complete" or "failed": no-op. Terminal.
+ */
+export async function driveCampaign(
+  context: TaskContext,
+  campaigns: Awaited<ReturnType<TaskContext["collection"]>>,
+  campaign: Campaign,
+) {
+  if (campaign.status === "snapshotting") {
+    await driveSnapshot(context, campaigns, campaign);
+    return;
+  }
+  if (campaign.status === "paying") {
+    await drivePayouts(context, campaigns, campaign);
+    return;
+  }
+}
+
+async function driveSnapshot(
+  context: TaskContext,
+  campaigns: Awaited<ReturnType<TaskContext["collection"]>>,
+  campaign: Campaign,
+) {
+  const aggTable = aggTableName(campaign.userId);
+
+  for (let i = 0; i < MAX_POLLS_PER_TICK; i++) {
+    const state = await getPipelineState(context, campaign.pipelineName);
+
+    if (state === "error") {
+      await markFailed(
+        context,
+        campaigns,
+        campaign,
+        "pipeline entered error state",
+      );
+      return;
+    }
+
+    // The Postgres sink commits the table on its FIRST checkpoint — even
+    // an empty epoch creates the schema. So we have to count rows, not
+    // just check the table exists, or a brief `/state` 404 mid-scan can
+    // race the driver into transitioning to `paying` while the pipeline
+    // is still scanning ahead of the share token's deploy block.
+    //
+    // Two paths to "snapshot ready":
+    //   1. Pipeline reports completed/paused/stopped AND the table has
+    //      ≥1 row.
+    //   2. Pipeline state is `unknown` (404 from the auto-cleanup path
+    //      that follows a successful job-mode run) AND the table has
+    //      ≥1 row.
+    //
+    // If state is terminal but the table is empty, that's a structural
+    // failure (or a token with no holders, which for a corp-action is
+    // also operationally a failure).
+    const rowCount = await aggTableRowCount(context, aggTable);
+    console.log(
+      `[${campaign.userId}] poll i=${i} state=${state} rowCount=${rowCount}`,
+    );
+    const sawTerminalState = state === "completed";
+
+    if (sawTerminalState && (rowCount === null || rowCount === 0)) {
+      await markFailed(
+        context,
+        campaigns,
+        campaign,
+        `pipeline completed but ${aggTable} has no rows ` +
+          `(token may have no transfers, or pipeline failed silently)`,
+      );
+      return;
+    }
+
+    const haveRows = rowCount !== null && rowCount > 0;
+    const looksAutoCleaned = state === "unknown" && haveRows;
+
+    if ((sawTerminalState && haveRows) || looksAutoCleaned) {
+      console.log(`[${campaign.userId}] snapshot completed → paying`);
+      const updated: Campaign = {
+        ...campaign,
+        status: "paying",
+        snapshotCompletedAt: Date.now(),
+      };
+      await campaigns.setById(campaign.rowId, updated);
+      // Don't re-read from the collection here — same Neon pool-stickiness
+      // bug we hit on user tables means setById's write may not be visible
+      // to an immediate getById on the same connection. We have the new
+      // value in-memory; pass it through directly.
+      await drivePayouts(context, campaigns, updated);
+      return;
+    }
+
+    // running / starting / unknown-without-rows → keep waiting
+    if (i < MAX_POLLS_PER_TICK - 1) {
+      await sleep(STATE_POLL_INTERVAL_MS);
+    }
+  }
+  console.log(
+    `[${campaign.userId}] snapshot still in-flight after ${MAX_POLLS_PER_TICK} polls; ` +
+      `re-call declare_campaign with the same id to resume`,
+  );
+}
+
+async function drivePayouts(
+  context: TaskContext,
+  campaigns: Awaited<ReturnType<TaskContext["collection"]>>,
+  campaign: Campaign,
+) {
+  console.log(`[${campaign.userId}] drivePayouts: start`);
+  const aggTable = aggTableName(campaign.userId);
+  const holders = await getHolders(context, aggTable);
+  console.log(`[${campaign.userId}] drivePayouts: holders=${holders.length}`);
+  if (holders.length === 0) {
+    // The snapshot completed (the agg table exists) but contains zero rows.
+    // For a corporate-action distribution this is always a failure — either
+    // the pipeline pod silently failed before writing data, or the operator
+    // declared against a token with no holders. Surface it; the operator can
+    // recover escrow via DistributionCampaign.seal().
+    await markFailed(
+      context,
+      campaigns,
+      campaign,
+      "snapshot returned 0 holders (pipeline may have failed to index)",
+    );
+    return;
+  }
+
+  const totalSupply = holders.reduce((s, h) => s + h.balance, 0n);
+  const payouts = proRata(holders, BigInt(campaign.totalAmount), totalSupply);
+
+  // Persist payouts onto the campaign row so the holder/amount table
+  // survives terminalCleanup (which drops the per-campaign Postgres
+  // table). Useful for audit + for operator UIs reading campaign state
+  // after the per-campaign tables have been cleaned up.
+  if (!campaign.payouts) {
+    const persisted: PersistedPayout[] = payouts.map((p) => ({
+      holder: p.holder,
+      sharesAtSnapshot: p.sharesAtSnapshot.toString(),
+      amount: p.amount.toString(),
+    }));
+    campaign.payouts = persisted;
+    await campaigns.setById(campaign.rowId, campaign);
+  }
+
+  const wallet = await context.evm.wallet({
+    name: "corp-actions-operator",
+    sponsorGas: true,
+  });
+  const chain = context.evm.chains[CONFIG.chain];
+
+  // Filter to unpaid holders by reading on-chain state. The contract is the
+  // sole source of truth — if the pod was killed mid-batch on a previous
+  // call, the already-paid holders show up here as paid and we skip them.
+  const unpaid: Payout[] = [];
+  for (const p of payouts) {
+    const isAlreadyPaid = await wallet.readContract(
+      chain,
+      CONFIG.campaignContract,
+      "isPaid(bytes32,address)",
+      [campaign.onChainId, p.holder],
+    );
+    if (!isAlreadyPaid) unpaid.push(p);
+  }
+
+  console.log(
+    `[${campaign.userId}] drivePayouts: unpaid=${unpaid.length}/${payouts.length}`,
+  );
+  if (unpaid.length === 0) {
+    await maybeMarkComplete(context, campaigns, campaign, payouts);
+    return;
+  }
+
+  // Bounded concurrency. Promise.allSettled so one revert doesn't break the
+  // whole batch — the contract's `AlreadyPaid` guard means duplicates are
+  // safe even when we're optimistic about parallel state.
+  const txByHolder = new Map<string, string>();
+  for (let i = 0; i < unpaid.length; i += CONCURRENCY) {
+    const batch = unpaid.slice(i, i + CONCURRENCY);
+    console.log(`[${campaign.userId}] drivePayouts: sending batch ${batch.length}`);
+    const results = await Promise.allSettled(
+      batch.map((p) => payOne(wallet, chain, campaign, p)),
+    );
+    results.forEach((res, idx) => {
+      if (res.status === "fulfilled" && res.value) {
+        txByHolder.set(batch[idx].holder.toLowerCase(), res.value);
+      }
+    });
+  }
+
+  // Stitch tx hashes back into the persisted payouts so audit tooling
+  // can deep-link each holder row to the actual pay() tx on basescan.
+  if (txByHolder.size && campaign.payouts) {
+    let mutated = false;
+    for (const p of campaign.payouts) {
+      const tx = txByHolder.get(p.holder.toLowerCase());
+      if (tx && !p.payTxHash) {
+        p.payTxHash = tx as `0x${string}`;
+        mutated = true;
+      }
+    }
+    if (mutated) await campaigns.setById(campaign.rowId, campaign);
+  }
+
+  console.log(`[${campaign.userId}] drivePayouts: batches done, checking escrow`);
+  // Re-read on-chain state to decide if we're done.
+  await maybeMarkComplete(context, campaigns, campaign, payouts);
+}
+
+async function payOne(
+  wallet: Awaited<ReturnType<TaskContext["evm"]["wallet"]>>,
+  chain: TaskContext["evm"]["chains"][keyof TaskContext["evm"]["chains"]],
+  campaign: Campaign,
+  { holder, amount, sharesAtSnapshot }: Payout,
+): Promise<string | null> {
+  try {
+    const { hash } = await wallet.writeContract(
+      chain,
+      CONFIG.campaignContract,
+      "pay(bytes32,address,uint256,uint256)",
+      [
+        campaign.onChainId,
+        holder,
+        amount.toString(),
+        sharesAtSnapshot.toString(),
+      ],
+    );
+    return hash;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/AlreadyPaid/.test(msg)) return null;       // contract guard absorbed a race
+    if (/AlreadySealed|InsufficientEscrow/.test(msg)) {
+      console.log(`[${campaign.userId}] terminal pay failure for ${holder}: ${msg}`);
+      return null;
+    }
+    console.log(`[${campaign.userId}] transient pay failure for ${holder}: ${msg}`);
+    return null;
+  }
+}
+
+async function maybeMarkComplete(
+  context: TaskContext,
+  campaigns: Awaited<ReturnType<TaskContext["collection"]>>,
+  campaign: Campaign,
+  payouts: Payout[],
+) {
+  if (campaign.status === "complete") return;
+
+  // Source of truth for "is this campaign fully distributed" is the
+  // contract's `escrowRemaining`. A single read, atomic.
+  //
+  // The previous implementation looped N `isPaid()` reads instead — which
+  // looked correct but had a real failure mode: with sponsored gas + a
+  // cluster of pay() txs, individual RPC nodes can return a stale `false`
+  // for an isPaid that's actually true on chain. One stale read kept the
+  // campaign in `paying` forever and re-fired pay() (silently absorbed by
+  // the AlreadyPaid guard, but noisy in operator logs). escrowRemaining=0
+  // is a single signal that's already resolved by the contract's
+  // checks-effects-interactions on every pay().
+  const wallet = await context.evm.wallet({
+    name: "corp-actions-operator",
+    sponsorGas: true,
+  });
+  const chain = context.evm.chains[CONFIG.chain];
+  const c = await wallet.readContract<
+    readonly [
+      `0x${string}`, `0x${string}`, `0x${string}`,
+      bigint, bigint, bigint,
+      boolean, boolean,
+    ]
+  >(
+    chain,
+    CONFIG.campaignContract,
+    "campaigns(bytes32) view returns (address,address,address,uint256,uint256,uint256,bool,bool)",
+    [campaign.onChainId],
+  );
+  const escrowRemaining = c[4];
+  console.log(
+    `[${campaign.userId}] maybeMarkComplete: escrowRemaining=${escrowRemaining}`,
+  );
+  if (escrowRemaining > 0n) return; // not done; caller can re-drive to keep paying
+
+  await terminalCleanup(context, campaign);
+  await campaigns.setById(campaign.rowId, {
+    ...campaign,
+    status: "complete",
+    completedAt: Date.now(),
+  });
+  console.log(`[${campaign.userId}] complete: paid ${payouts.length} holders`);
+}
+
+async function markFailed(
+  context: TaskContext,
+  campaigns: Awaited<ReturnType<TaskContext["collection"]>>,
+  campaign: Campaign,
+  reason: string,
+) {
+  await terminalCleanup(context, campaign);
+  await campaigns.setById(campaign.rowId, {
+    ...campaign,
+    status: "failed",
+    failedAt: Date.now(),
+    failureReason: reason,
+  });
+  console.log(`[${campaign.userId}] failed: ${reason}`);
+}
+
+/**
+ * Belt-and-suspenders cleanup. Turbo auto-deletes successful job-mode
+ * pipelines ~1h after completion, but errored jobs stay around forever
+ * unless we DELETE them. We always run both regardless of terminal status
+ * so the user's account stays clean across many demo runs.
+ *
+ * Order matters: DELETE the pipeline first (releases the sink writer's
+ * connection), THEN drop the tables.
+ */
+async function terminalCleanup(context: TaskContext, campaign: Campaign) {
+  await deletePipeline(context, campaign.pipelineName).catch(() => {});
+  const transfers = aggTableName(campaign.userId);
+  await dropCampaignTables(context, transfers).catch(() => {});
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+```
+
+### `src/lib/turbo.ts`
+
+```typescript
+import type { TaskContext } from "compose";
+import {
+  aggTableName,
+  CONFIG,
+  pipelineName,
+} from "./constants";
+import type { Hex } from "./types";
+
+/**
+ * HTTP client for Goldsky's Turbo pipeline API. Same endpoints the `goldsky`
+ * CLI uses, talking directly to api.goldsky.com over public ingress (the
+ * compose pod has outbound network for this).
+ *
+ * Auth is a project API token surfaced as `context.env.GOLDSKY_PROJECT_KEY`
+ * — declared in compose.yaml's `secrets:` block, set once via
+ * `goldsky secret create GOLDSKY_PROJECT_KEY <value>`.
+ */
+
+const API_BASE = "https://api.goldsky.com/api/v1";
+
+function authHeaders(env: Record<string, string>): Record<string, string> {
+  const key = env.GOLDSKY_PROJECT_KEY;
+  if (!key) {
+    throw new Error(
+      "GOLDSKY_PROJECT_KEY missing — declare it under `secrets:` in compose.yaml " +
+        "and set its value with `goldsky secret create GOLDSKY_PROJECT_KEY <key>`",
+    );
+  }
+  return {
+    Authorization: `Bearer ${key}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export type TurboState =
+  | "running"
+  | "starting"
+  | "paused"
+  | "stopped"
+  | "error"
+  | "completed"
+  | "unknown";
+
+interface StateResponse {
+  status?: string;
+  state?: string;
+  errors?: unknown;
+  success?: boolean;
+  error?: string;
+}
+
+/**
+ * Build the job-mode pipeline definition that snapshots holders of a single
+ * ERC-20 at a specific block.
+ *
+ * Why `erc20_transfers` and not `logs`?
+ *   `job: true` requires every source to be a "hybrid source" (one that
+ *   supports a bounded backfill). On Base mainnet, `logs` is NOT hybrid;
+ *   `erc20_transfers` is. (Pipeline that tried `base.logs` failed with
+ *   `job_mode is enabled but the following source(s) do not support it`.)
+ *
+ * Why `to_u256(amount)` before the cast?
+ *   `erc20_transfers.amount` is `FixedSizeBinary(32)` and DataFusion has no
+ *   direct cast from FixedSizeBinary to DOUBLE/DECIMAL. `to_u256` is the
+ *   canonical bridge — it returns a numeric type that casts cleanly.
+ *   (See the failing `corp-actions-5a06330a7f49ce61` pod which tripped on
+ *   `Unsupported CAST from FixedSizeBinary(32) to Float64`.)
+ *
+ * Pieces:
+ *   - source: `base.erc20_transfers` with `start_at: earliest` (required for
+ *     hybrid-source / job-mode), narrowed by a filter that bounds both ends
+ *     of the scan: `lower(address) = <token> AND block_number BETWEEN
+ *     <deployBlock> AND <recordBlock>`. Per Jeff: a filter-level lower+upper
+ *     block range is dramatically faster than a source-level `end_block`
+ *     because the planner can prune partitions/files before scanning.
+ *   - transform: split each Transfer into `+amount` at `recipient` and
+ *     `-amount` at `sender` (skip zero-address sender for mints)
+ *   - sink: postgres_aggregate sums per-account deltas into a per-campaign
+ *     agg table so concurrent campaigns can't collide on SUM
+ */
+export function buildSnapshotPipeline(input: {
+  campaignId: string;
+  shareToken: Hex;
+  recordBlock: bigint;
+}): Record<string, unknown> {
+  const transfersTable = aggTableName(input.campaignId);
+  const tokenLower = input.shareToken.toLowerCase();
+  const startBlock = CONFIG.shareTokenDeployBlock;
+  const endBlock = Number(input.recordBlock);
+
+  return {
+    resource_size: "s",
+    job: true,
+    sources: {
+      transfers: {
+        type: "dataset",
+        dataset_name: `${CONFIG.turboChain}.erc20_transfers`,
+        version: "1.2.0",
+        // `start_at` MUST be 'earliest' for hybrid-source / job-mode
+        // semantics. Setting it to a block number makes the source
+        // non-hybrid and Turbo refuses to run with job:true. The
+        // block-range filter below carries the actual scan bounds.
+        start_at: "earliest",
+        filter:
+          `lower(address) = '${tokenLower}' ` +
+          `AND block_number BETWEEN ${startBlock} AND ${endBlock}`,
+      },
+    },
+    // The v1 pipelines API requires a `transforms` object even when there's
+    // nothing to do — leave it empty.
+    transforms: {},
+    // Why no SQL transform?
+    //   We tried — extensively. `amount` arrives as `FixedSizeBinary(32)` at
+    //   the DataFusion layer and there is no in-pipeline conversion to a
+    //   numeric/decimal that the planner accepts. Every UDF route either
+    //   silently passes binary through (invalid Utf8 downstream),
+    //   misinterprets hex as decimal, or hits "Unsupported CAST from
+    //   FixedSizeBinary(32) to <T>". The Postgres sink, however, has its
+    //   own binary→numeric mapping. So we sink the raw Transfer rows and
+    //   compute balances via a SQL aggregate over Postgres at read time
+    //   (see `getHolders` in lib/db.ts). One more network round-trip per
+    //   campaign in exchange for not fighting DataFusion.
+    sinks: {
+      transfers_sink: {
+        type: "postgres",
+        from: "transfers",
+        schema: "public",
+        table: transfersTable,
+        primary_key: "id",
+        secret_name: "CORPORATE_ACTIONS",
+      },
+    },
+  };
+}
+
+export async function createSnapshotPipeline(
+  ctx: TaskContext,
+  input: {
+    campaignId: string;
+    shareToken: Hex;
+    recordBlock: bigint;
+  },
+): Promise<{ name: string }> {
+  const name = pipelineName(input.campaignId);
+  const definition = buildSnapshotPipeline(input);
+
+  const body = {
+    name,
+    resource_size: "s",
+    description: `Holder snapshot for campaign ${input.campaignId} at block ${input.recordBlock}`,
+    definition,
+  };
+
+  console.log(
+    `[turbo] POST /pipelines: name=${name}, ` +
+      `block_range=[${CONFIG.shareTokenDeployBlock}, ${input.recordBlock}]`,
+  );
+  try {
+    const res = await ctx.fetch(`${API_BASE}/pipelines`, {
+      method: "POST",
+      headers: authHeaders(ctx.env),
+      body,
+    });
+    console.log(`[turbo] POST /pipelines response: ${JSON.stringify(res).slice(0, 500)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.log(`[turbo] POST /pipelines threw: ${msg}`);
+    throw err;
+  }
+  return { name };
+}
+
+/**
+ * Read raw upstream pipeline state.
+ *
+ * NB: we use `/state` (proxied unchanged from streamling) NOT `/status`. The
+ * v1 `/status` endpoint runs a status normalizer that maps `completed` →
+ * `"UNKNOWN"`, which would silently break job-mode termination detection.
+ */
+export async function getPipelineState(
+  ctx: TaskContext,
+  name: string,
+): Promise<TurboState> {
+  try {
+    // Use `/state` (proxied to streamling-agent) NOT `/pipelines/<name>` or
+    // `/status` — those return CACHED registry data that lags k8s by minutes
+    // (or forever for job-mode pipelines that were cleaned up). `/state`
+    // queries the actual k8s deployment, so it's the only reliable source
+    // for "did the pipeline finish".
+    const res = await ctx.fetch<StateResponse>(
+      `${API_BASE}/pipelines/${encodeURIComponent(name)}/state`,
+      { method: "GET", headers: authHeaders(ctx.env) },
+    );
+
+    // streamling-agent returns `{success: false, error: "...not found"}`
+    // when the k8s deployment is gone — which for a job-mode pipeline means
+    // it completed and was cleaned up. The caller (driveSnapshot) treats
+    // this as "unknown" + uses the per-campaign table's row count as the
+    // actual success signal.
+    if (res?.success === false) {
+      const errMsg = String(res?.error ?? "").toLowerCase();
+      if (/not found|missing|deployments?\b/i.test(errMsg)) return "unknown";
+    }
+
+    const raw = (res?.status ?? res?.state ?? "unknown").toString().toLowerCase();
+    console.log(`[turbo] /state(${name}) raw=${raw}`);
+    if (
+      raw === "completed" || raw === "complete" ||
+      raw === "succeeded" || raw === "success" ||
+      raw === "finished" ||
+      raw === "paused" || raw === "stopped"
+    ) {
+      return "completed";
+    }
+    if (raw === "running" || raw === "starting" || raw === "deploying") {
+      return "running";
+    }
+    if (raw === "error" || raw === "failed") return "error";
+    return "unknown";
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Direct 404 (pipeline registry entry has been deleted) — same as the
+    // "deployment not found" case above: treat as unknown, let the caller
+    // decide based on the table contents.
+    if (/404|not found/i.test(msg)) return "unknown";
+    throw err;
+  }
+}
+
+export async function deletePipeline(
+  ctx: TaskContext,
+  name: string,
+): Promise<void> {
+  try {
+    await ctx.fetch(
+      `${API_BASE}/pipelines/${encodeURIComponent(name)}`,
+      { method: "DELETE", headers: authHeaders(ctx.env) },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Idempotent: a 404 just means the pipeline was already cleaned up. Any
+    // other error is real and the caller should know about it.
+    if (!/404|not found/i.test(msg)) throw err;
+  }
+}
+```
+
+### `contracts/DistributionCampaign.sol`
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}
+
+/**
+ * @title DistributionCampaign
+ * @notice On-chain audit-trail + double-pay guard for tokenized corporate-action distributions
+ *         (dividends, coupons, rebates, rewards). Operator-supplied per-holder amounts; the
+ *         contract enforces escrow caps and one-time payment per holder.
+ *
+ * @dev Many campaigns can coexist in a single deployed instance; each is keyed by a canonical
+ *      `id = keccak256(operator, userId)` to namespace user-supplied IDs across operators.
+ *
+ *      Reverts use string `require` messages (not custom errors) so off-chain callers can
+ *      decode them via the standard `Error(string)` selector.
+ *
+ *      Demo-grade. Not audited. Anyone can `declare()` a campaign with their own funds; the
+ *      operator address is recorded and only the operator can `pay()` or `seal()` that campaign.
+ */
+contract DistributionCampaign {
+    struct Campaign {
+        address operator;        // wallet that called declare(); only caller for pay/seal
+        address payToken;        // ERC-20 used for payouts (e.g. MockUSDC)
+        address shareToken;      // tokenized equity reference (informational; for audit reconciliation)
+        uint256 totalAmount;     // initial escrow pulled from operator at declare time
+        uint256 escrowRemaining; // decremented per pay(); refunded on seal()
+        uint256 recordBlock;     // snapshot block at declare time (audit reference)
+        bool    declared;        // set on declare; prevents re-declare under same id
+        bool    sealed_;         // terminal; no more pay() allowed
+    }
+
+    /// @notice campaigns[canonicalId]
+    mapping(bytes32 => Campaign) public campaigns;
+
+    /// @notice paid[canonicalId][holder] = amount (0 means unpaid)
+    mapping(bytes32 => mapping(address => uint256)) public paid;
+
+    event CampaignDeclared(
+        bytes32 indexed id,
+        address indexed operator,
+        address payToken,
+        address shareToken,
+        uint256 totalAmount,
+        uint256 recordBlock
+    );
+    event HolderPaid(
+        bytes32 indexed id,
+        address indexed holder,
+        address payToken,         // included so auditors don't need a separate getCampaign call
+        uint256 amount,
+        uint256 sharesAtSnapshot  // operator-supplied; lets auditors recompute pro-rata independently
+    );
+    event CampaignSealed(bytes32 indexed id, uint256 refunded);
+
+    /// @notice Derive canonical id from operator + user-supplied id. Anyone can call this view to
+    ///         compute the id off-chain before tx submission.
+    function canonicalId(address operator, bytes32 userId) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(operator, userId));
+    }
+
+    /// @notice Open a new campaign. Pulls `totalAmount` of `payToken` from msg.sender atomically.
+    ///         The record block is `block.number` of the declare tx — the off-chain indexer
+    ///         must wait for that block + finality depth before reading the snapshot.
+    /// @param userId      operator-supplied identifier; canonical id = keccak256(operator, userId)
+    /// @param payToken    ERC-20 used for payouts
+    /// @param shareToken  reference share token (informational; recorded in events)
+    /// @param totalAmount total escrow to pull from msg.sender via transferFrom
+    /// @return id         canonical id
+    function declare(
+        bytes32 userId,
+        address payToken,
+        address shareToken,
+        uint256 totalAmount
+    ) external returns (bytes32 id) {
+        id = canonicalId(msg.sender, userId);
+        Campaign storage c = campaigns[id];
+        require(!c.declared, "AlreadyDeclared");
+        require(totalAmount > 0, "ZeroAmount");
+
+        c.operator = msg.sender;
+        c.payToken = payToken;
+        c.shareToken = shareToken;
+        c.totalAmount = totalAmount;
+        c.escrowRemaining = totalAmount;
+        c.recordBlock = block.number;
+        c.declared = true;
+
+        require(IERC20(payToken).transferFrom(msg.sender, address(this), totalAmount), "TransferFromFailed");
+
+        emit CampaignDeclared(id, msg.sender, payToken, shareToken, totalAmount, block.number);
+    }
+
+    /// @notice Pay one holder for one campaign. Idempotent — reverts `AlreadyPaid` on duplicate.
+    /// @dev Strict checks-effects-interactions: paid[] and escrowRemaining are updated BEFORE the
+    ///      external transfer to defeat any reentrancy hook in a swapped-in pay token.
+    function pay(
+        bytes32 id,
+        address holder,
+        uint256 amount,
+        uint256 sharesAtSnapshot
+    ) external {
+        Campaign storage c = campaigns[id];
+        require(c.declared, "NotDeclared");
+        require(!c.sealed_, "AlreadySealed");
+        require(msg.sender == c.operator, "NotOperator");
+        require(paid[id][holder] == 0, "AlreadyPaid");
+        require(c.escrowRemaining >= amount, "InsufficientEscrow");
+        require(amount > 0, "ZeroAmount");
+
+        // Effects
+        paid[id][holder] = amount;
+        c.escrowRemaining -= amount;
+
+        // Interaction
+        require(IERC20(c.payToken).transfer(holder, amount), "TransferFailed");
+
+        emit HolderPaid(id, holder, c.payToken, amount, sharesAtSnapshot);
+    }
+
+    /// @notice Close out a campaign and return any unpaid escrow to the operator.
+    function seal(bytes32 id) external {
+        Campaign storage c = campaigns[id];
+        require(c.declared, "NotDeclared");
+        require(!c.sealed_, "AlreadySealed");
+        require(msg.sender == c.operator, "NotOperator");
+
+        uint256 refund = c.escrowRemaining;
+        c.escrowRemaining = 0;
+        c.sealed_ = true;
+
+        if (refund > 0) {
+            require(IERC20(c.payToken).transfer(c.operator, refund), "TransferFailed");
+        }
+        emit CampaignSealed(id, refund);
+    }
+
+    /// @notice Read the full campaign struct.
+    function getCampaign(bytes32 id) external view returns (Campaign memory) {
+        return campaigns[id];
+    }
+
+    /// @notice True if `holder` has been paid for `id`.
+    function isPaid(bytes32 id, address holder) external view returns (bool) {
+        return paid[id][holder] != 0;
+    }
+}
+```
+
+### `contracts/MockUSDC.sol`
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title MockUSDC
+ * @notice 6-decimal mock stablecoin with permissionless mint, suitable for testnet demos only.
+ * @dev Permissionless `mint` is intentional — anyone can fund any wallet for the demo.
+ *      Do NOT use this contract in any production setting.
+ */
+contract MockUSDC {
+    string public constant name = "Mock USDC";
+    string public constant symbol = "mUSDC";
+    uint8  public constant decimals = 6;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    error InsufficientBalance();
+    error InsufficientAllowance();
+
+    /// @notice Permissionless mint — anyone can mint to anyone. Demo only.
+    function mint(address to, uint256 value) external {
+        balanceOf[to] += value;
+        totalSupply += value;
+        emit Transfer(address(0), to, value);
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 a = allowance[from][msg.sender];
+        if (a < value) revert InsufficientAllowance();
+        if (a != type(uint256).max) {
+            allowance[from][msg.sender] = a - value;
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        uint256 b = balanceOf[from];
+        if (b < value) revert InsufficientBalance();
+        unchecked { balanceOf[from] = b - value; }
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+    }
+}
+```
+
+### `contracts/ShareToken.sol`
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title ShareToken
+ * @notice Minimal ERC-20 representing tokenized equity shares.
+ *         Pre-mints to a list of holders in the constructor.
+ *
+ * @dev Demo-grade: no permits, no transfer hooks, no ERC-2612.
+ */
+contract ShareToken {
+    string public constant name = "Example Issuer Shares";
+    string public constant symbol = "EIS";
+    uint8  public constant decimals = 18;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    error LengthMismatch();
+    error InsufficientBalance();
+    error InsufficientAllowance();
+
+    constructor(address[] memory holders, uint256[] memory amounts) {
+        if (holders.length != amounts.length) revert LengthMismatch();
+        uint256 supply;
+        for (uint256 i = 0; i < holders.length; i++) {
+            balanceOf[holders[i]] += amounts[i];
+            supply += amounts[i];
+            emit Transfer(address(0), holders[i], amounts[i]);
+        }
+        totalSupply = supply;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 a = allowance[from][msg.sender];
+        if (a < value) revert InsufficientAllowance();
+        if (a != type(uint256).max) {
+            allowance[from][msg.sender] = a - value;
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        uint256 b = balanceOf[from];
+        if (b < value) revert InsufficientBalance();
+        unchecked { balanceOf[from] = b - value; }
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+    }
+}
+```
 
 ## Step 0b — Scaffold the example
 
@@ -214,6 +1683,13 @@ cast call 0xA8e58573B1e10908b63d12B603aCF9C784BF904E \
 ```
 
 Returned fields, in order: `operator, payToken, shareToken, totalAmount, escrowRemaining, recordBlock, declared, sealed_`. `escrowRemaining` (the **5th** value) is exactly `0` once all 25 holders are paid. The full audit trail is the contract's `HolderPaid` events.
+
+## Set your secret (final step)
+
+The app is deployed but won't run until the `GOLDSKY_PROJECT_KEY` secret is set AND the app is (re)deployed with it. The running app uses it to spawn, poll, and delete the job-mode Turbo pipelines (see `src/lib/turbo.ts`).
+
+- **In-app (chatbot):** the in-app deploy skips secret validation, so `deployComposeApp` succeeds without the secret. After deploy, add `GOLDSKY_PROJECT_KEY` in the Compose app's dashboard under the app's **Secrets** page, then **redeploy from the dashboard** so the pod picks it up. The app does not start working on set alone; secrets are baked into the pod at deploy, not hot-reloaded, so the redeploy is required. NEVER attempt to set a secret from chat; there is no tool, by design.
+- **CLI:** you set this in Step 2 (it must exist before the CLI deploy, which validates and bakes it in). If you skipped it: `goldsky compose secret set GOLDSKY_PROJECT_KEY --value <your project API key>`, then redeploy so the pod picks it up.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Follows FOU-998 (chatbot `walletCreate` + `deployContract` tools). Makes the last two contract-requiring templates fully in-app deployable and fixes the secrets story.

- **dividend-distribution** — inlines the full app source (HTTP task + 6-file lib + 3 contracts + manifest) so the chatbot can scaffold + `deployComposeApp` it in-app. The old "can't deploy in-app" claim was wrong: the job-mode Turbo pipeline is spawned at **runtime via the Turbo API**, not provisioned at deploy. (ABI JSONs, the `deno.d.ts` shim, and the unused `OpenShareToken.sol` are intentionally not inlined — the app uses raw `wallet.writeContract`/`readContract`.)
- **compliance-oracle** — switches the oracle from a BYO `ORACLE_PRIVATE_KEY` to a named **Compose smart wallet** (`compliance-oracle-wallet`), same pattern bitcoin-oracle/vrf use: `walletCreate` → pass its address as the `oracle` constructor arg → the app signs approve/reject via that wallet. Drops the private-key secret, `api_version: stable`. BYO-key preserved as a documented advanced/production option. Now fully in-app.
- **secrets are the user's own last step, stated honestly** — CLI sets them *before* `compose deploy` (deploy bakes + validates); in-app deploys without them (validation skipped) then the user adds them in the app's dashboard **and redeploys** (secrets are baked at deploy, not hot-reloaded). dividend also notes the demo's mint/approve needs CLI/dashboard (no `writeContract` chatbot tool yet).

## Testing

- `npm run validate` green.
- Adversarial review: all 12 inlined dividend files verified **byte-identical** to the source; compliance oracle switch verified sound (contract unchanged, `msg.sender == smart-account == oracle` holds, `stable` + sponsored named-wallet parity). Money-critical `walletCreate` signature fix applied (must pass `walletName`, not a positional appName, or escrow would be stranded).

## Follow-up

A `writeContract` chatbot tool (same server-endpoint-wrapper pattern as `walletCreate`/`deployContract`) would let the chatbot do on-chain *setup* calls (mint/approve) so demos like dividend run fully hands-off in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)