### PR TITLE
docs(skills): harden credential/secret handling in high-risk skills (APP-5017)

### DIFF
--- a/skills/auth-setup/SKILL.md
+++ b/skills/auth-setup/SKILL.md
@@ -61,7 +61,7 @@ goldsky project list 2>&1
 
 **Do NOT attempt interactive login.** Always use token-based authentication.
 
-**Do NOT use AskUserQuestion for token input.** Simply ask the user to paste their token directly in the chat:
+**Do NOT use AskUserQuestion for token input.** Simply ask the user to paste their token directly in the chat. The token is a sensitive credential — do not echo it back, log it, or store it anywhere beyond the `goldsky login` call below:
 
 ```
 You're not logged in. Please paste your API token:

--- a/skills/auth-setup/SKILL.md
+++ b/skills/auth-setup/SKILL.md
@@ -57,36 +57,34 @@ goldsky project list 2>&1
 
 **Not logged in:** Output contains `Make sure to run 'goldsky login'`. Continue to Step 3.
 
-### Step 3: Token-Based Login
+### Step 3: Have the User Log In
 
-**Do NOT attempt interactive login.** Always use token-based authentication.
+**Never handle the user's API token in the chat.** A token pasted into the conversation ends up in the transcript and is sent to the model — treat it like a password you must never see. Have the user authenticate themselves in their own terminal instead. The CLI persists credentials to disk, so the `goldsky` commands you run afterward will pick up their session automatically.
 
-**Do NOT use AskUserQuestion for token input.** Simply ask the user to paste their token directly in the chat. The token is a sensitive credential — do not echo it back, log it, or store it anywhere beyond the `goldsky login` call below:
-
-```
-You're not logged in. Please paste your API token:
-
-(Need a token? Go to https://app.goldsky.com → Settings → API Tokens → Create Token)
-```
-
-Wait for the user to paste their token in their next message.
-
-**If user says they don't have a token or need help:**
-Explain the steps:
-
-1. Go to https://app.goldsky.com
-2. Click Settings → API Tokens
-3. Click "Create Token" and give it a name
-4. Copy the token (it won't be shown again)
-
-Then ask them to paste it.
-
-**Once user provides the token:**
-Log them in:
+Ask the user to run login themselves:
 
 ```bash
-goldsky login --token USER_PROVIDED_TOKEN
+goldsky login                       # opens a browser to authenticate (simplest)
+# or, if they prefer a token or have no browser available:
+goldsky login --token <YOUR_TOKEN>  # they type this themselves — do not ask them to paste the token to you
 ```
+
+Need a token? Go to https://app.goldsky.com → Settings → API Tokens → Create Token (it won't be shown again).
+
+Use AskUserQuestion to confirm — do NOT collect the token yourself:
+
+```
+Question: "Run `goldsky login` in your terminal to authenticate, then let me know:"
+
+Options:
+1. Label: "Done, I'm logged in"
+   Description: "I ran login and it succeeded"
+
+2. Label: "I need help"
+   Description: "I hit an error during login"
+```
+
+Then verify (Step 4). If verification shows you're still not logged in, ask the user to re-run login — never ask them to hand you the token.
 
 ### Step 4: Verify Login
 
@@ -174,10 +172,10 @@ goldsky login
 
 | Issue             | Action                                                 |
 | ----------------- | ------------------------------------------------------ |
-| Not logged in     | Prompt user for API token, use `goldsky login --token` |
+| Not logged in     | Ask the user to run `goldsky login` themselves in their terminal |
 | Invalid token     | Ask user to generate a new token in dashboard          |
 | Permission denied | User needs role upgrade from project Owner/Admin       |
-| Session expired   | Prompt for new token and re-authenticate               |
+| Session expired   | Ask the user to re-run `goldsky login` themselves      |
 
 ## Related
 

--- a/skills/edge/SKILL.md
+++ b/skills/edge/SKILL.md
@@ -30,8 +30,8 @@ Replace `{chainId}` with the chain ID (e.g., `1` for Ethereum, `8453` for Base, 
 ### Authentication
 
 Three options:
-- **Query parameter**: `?secret=YOUR_SECRET`
-- **Header**: `X-ERPC-Secret-Token: YOUR_SECRET`
+- **Header (recommended)**: `X-ERPC-Secret-Token: YOUR_SECRET` — keeps the secret out of URLs, which are commonly logged by proxies, CDNs, and server access logs.
+- **Query parameter**: `?secret=YOUR_SECRET` — convenient for quick tests, but the secret leaks into any log that records the full URL. Prefer the header for production traffic. The examples below use the query param for brevity.
 - **x402 (pay-per-request)**: Clients without a secret receive an HTTP 402 response with payment requirements. An x402-compatible client signs a USDC payment and retries; Edge settles via a facilitator before forwarding the request upstream. Payment is settled on **Base** (chain `8453`) in USDC. Pricing is `$0.000005` per request (same as the standard `$5 per million` rate). See https://www.x402.org/ for the protocol spec.
 
 ### Example (curl)

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -9,6 +9,8 @@ Create and manage secrets for pipeline sink credentials.
 
 ## Agent Instructions
 
+**Handling credentials safely:** a credential passed inline via `--value '...'` is written to the user's shell history and is visible in the process list while the command runs. Whenever possible, omit `--value` on `goldsky secret create` and let the CLI prompt for the connection string interactively (nothing sensitive touches argv or history). Reserve inline `--value` for non-interactive scripting, and never echo a revealed secret (`goldsky secret reveal`) back into the conversation.
+
 When this skill is invoked, follow this streamlined workflow:
 
 ### Step 1: Verify Login + List Existing Secrets

--- a/skills/turbo-doctor/SKILL.md
+++ b/skills/turbo-doctor/SKILL.md
@@ -101,7 +101,7 @@ If the fix involves CLI commands (restart, update secrets, redeploy), offer to e
 
 Common fixes:
 - **Restart:** `goldsky turbo restart <name>` (or `--clear-state` for a fresh start)
-- **Update secret:** `goldsky secret create <name> --value <new-value>` (secrets are immutable — recreate to update)
+- **Update secret:** `goldsky secret create <name>` and let the CLI prompt for the value (secrets are immutable — recreate to update). Avoid passing the credential inline via `--value`, which stores it in shell history; see the `/secrets` skill. Never echo a revealed secret back into the conversation.
 - **Redeploy:** `goldsky turbo delete <name>` then `goldsky turbo apply <file.yaml>`
 - **Resume:** `goldsky turbo resume <name>` (for paused pipelines)
 


### PR DESCRIPTION
## What

Addresses the skills.sh security assessment (Gen / Socket / Snyk) flags on the non-compose high-risk skills — `auth-setup`, `secrets`, `edge`, `turbo-doctor` (APP-5017). Compose skills are out of scope (tracked in FOU-1000).

## Why they were flagged

The assessment runs three scanners built for npm packages against instructional markdown. They pattern-match on legitimate auth / secret-management / pipeline-repair instructions:

| Skill | Gen | Socket | Snyk | Trigger |
|---|---|---|---|---|
| auth-setup | High | 1 | Critical | `curl \| sh` installer, token pasted into chat + passed via `--token` |
| secrets | Med | 0 | High | passwords in `--value` argv, `secret reveal` |
| edge | Safe | 0 | High | key in URL (`?secret=`) |
| turbo-doctor | Safe | 0 | High | destructive cmds, `secret create --value` |

Most are **false positives**: `curl | sh` is Goldsky's official first-party installer (run by the user in their own terminal), and `?secret=` is the Edge API's own supported input — product-surface realities, not skill bugs.

## What this changes

- **auth-setup** — **stop handling the user's API token in the chat.** Previously the skill asked the user to paste their token into the conversation (where it lands in the transcript and is sent to the model) and then ran `goldsky login --token <arg>`. Now it tells the user to run `goldsky login` themselves in their terminal; the CLI persists the session to disk, so the agent's later commands pick it up without ever seeing the token. This removes the real, skill-fixable core of the Critical rating.
- **edge** — recommend header auth (`X-ERPC-Secret-Token`) over the `?secret=` query param, which leaks into proxy/CDN/server logs.
- **secrets** + **turbo-doctor** — credential-safety note: prefer the CLI's interactive prompt over inline `--value` (which lands in shell history); never echo a revealed secret back into the conversation.

Docs-only; no behavioral code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)