### PR TITLE
fix(datasets skill): replace non-working `dataset list` recipes (APP-5085)

### DIFF
--- a/skills/datasets/SKILL.md
+++ b/skills/datasets/SKILL.md
@@ -18,7 +18,9 @@ sources:
     start_at: earliest
 ```
 
-> **Tip:** Use `goldsky turbo validate` to verify a dataset exists (fast, ~3 seconds). Avoid `goldsky dataset list` which is slow (30-60+ seconds).
+> **Tip:** Verify a dataset exists with `goldsky turbo validate file.yaml` (fast, ~3s) or `goldsky dataset get <chain>.<dataset> --outputFormat json` (returns the exact slug, version, and schema). To browse or search datasets non-interactively, use `goldsky dataset list --output json` (optionally `--group <chain>`).
+>
+> ⚠️ **Plain `goldsky dataset list` with no flags is an interactive picker that only works in a real terminal** — in an agent/CI/piped context it produces **no output** at all. Always pass `--output json` (or `--group`). On an older CLI without those flags, fall back to the public read-only endpoint: `curl -s https://api.goldsky.com/api/public/datasets/v1`.
 
 ---
 
@@ -40,9 +42,10 @@ sources:
 
 | Action             | Command                               | Notes                        |
 | ------------------ | ------------------------------------- | ---------------------------- |
-| Validate dataset   | `goldsky turbo validate file.yaml`    | **Preferred - fast (3s)**    |
-| Search for dataset | `goldsky dataset list \| grep "name"` | Slow (30-60s), use sparingly |
-| List all datasets  | `goldsky dataset list`                | **Very slow - avoid**        |
+| Validate dataset     | `goldsky turbo validate file.yaml`                   | **Preferred - fast (3s)**                          |
+| Verify slug + schema | `goldsky dataset get <name> --outputFormat json`     | Exact slug, version, and schema                    |
+| Search datasets      | `goldsky dataset list --output json \| grep -i name` | Non-interactive                                    |
+| List all datasets    | `goldsky dataset list --output json`                 | Plain `dataset list` is TTY-only — always `--output json` |
 
 ---
 
@@ -176,7 +179,7 @@ All datasets use version `1.1.0`:
 
 ## Dataset Schemas
 
-> **Source:** [docs.goldsky.com](https://docs.goldsky.com/turbo-pipelines/sources/solana.md). Do not use field names not listed here — ask the user to run `goldsky dataset list` to inspect unknown schemas.
+> **Source:** [docs.goldsky.com](https://docs.goldsky.com/turbo-pipelines/sources/solana.md). Do not use field names not listed here — run `goldsky dataset get <chain>.<dataset> --outputFormat json` to inspect unknown schemas.
 
 ### Solana
 
@@ -282,7 +285,7 @@ All fields from `solana.transactions` plus:
 | `commission` | integer | |
 
 #### `solana.token_balances`
-> **Schema not fully documented** — do not guess field names. Inspect with `goldsky dataset list | grep solana.token_balances`.
+> **Schema not fully documented** — do not guess field names. Inspect with `goldsky dataset get solana.token_balances --outputFormat json`.
 
 ---
 
@@ -393,7 +396,7 @@ All datasets follow the pattern: `<chain_prefix>.<dataset_type>`
 Datasets are versioned. To find available versions:
 
 ```bash
-goldsky dataset list | grep "base.erc20"
+goldsky dataset get base.erc20_transfers --outputFormat json
 ```
 
 **Common versions:**
@@ -401,7 +404,7 @@ goldsky dataset list | grep "base.erc20"
 - `1.0.0` - Initial version
 - `1.2.0` - Enhanced schema (common for ERC-20 transfers)
 
-When in doubt, use the latest version shown in `goldsky dataset list`.
+When in doubt, use the latest version shown by `goldsky dataset get <name> --outputFormat json`.
 
 ---
 
@@ -463,14 +466,14 @@ Error: Source 'my_source' references unknown dataset 'invalid.dataset'
 
 1. Check the chain prefix is correct (e.g., `matic` not `polygon`)
 2. Check the dataset type exists (e.g., `erc20_transfers` not `erc20`)
-3. Run `goldsky dataset list` to see all available options
+3. Run `goldsky dataset list --output json` to see all available options
 
 ### Chain not listed
 
 If you can't find a chain in the tables above:
 
 ```bash
-goldsky dataset list | grep -i "<chain_name>"
+goldsky dataset list --output json | grep -i "<chain_name>"
 ```
 
 Some chains use non-obvious prefixes (e.g., Polygon uses `matic`).
@@ -484,7 +487,7 @@ Error: Version '2.0.0' not found for dataset 'base.erc20_transfers'
 **Fix:** Check available versions:
 
 ```bash
-goldsky dataset list | grep "base.erc20_transfers"
+goldsky dataset get base.erc20_transfers --outputFormat json
 ```
 
 Use a version that exists in the output.

--- a/skills/datasets/SKILL.md
+++ b/skills/datasets/SKILL.md
@@ -18,7 +18,7 @@ sources:
     start_at: earliest
 ```
 
-> **Tip:** Verify a dataset exists with `goldsky turbo validate file.yaml` (fast, ~3s) or `goldsky dataset get <chain>.<dataset> --outputFormat json` (returns the exact slug, version, and schema). To browse or search datasets non-interactively, use `goldsky dataset list --output json` (optionally `--group <chain>`).
+> **Tip:** Verify a dataset exists with `goldsky dataset get <chain>.<dataset> --outputFormat json` — returns the exact slug, version, schema, and `isTurboOnly` (`false` = usable by Turbo **and** Mirror; `true` = Turbo-only). To browse or search: `goldsky dataset list --output json` (optionally `--group <chain>`; the list is a slim index and omits `isTurboOnly` — use `dataset get` for that). `goldsky turbo validate file.yaml` validates a whole **Turbo** pipeline config — it is *not* a dataset-existence check (Turbo-specific, needs the `turbo` binary).
 >
 > ⚠️ **Plain `goldsky dataset list` with no flags is an interactive picker that only works in a real terminal** — in an agent/CI/piped context it produces **no output** at all. Always pass `--output json` (or `--group`). On an older CLI without those flags, fall back to the public read-only endpoint: `curl -s https://api.goldsky.com/api/public/datasets/v1`.
 
@@ -34,7 +34,7 @@ sources:
 
 **Data location:** `data/` (relative to this skill's directory)
 
-> **Dataset versions are not pinned in this skill.** Version numbers drift as datasets are revised, so confirm the exact version with `goldsky turbo validate file.yaml` (fast, ~3s) rather than trusting a static list. The dataset-type and schema tables below are stable references; treat any version number in them as a starting point to validate, not ground truth.
+> **Dataset versions are not pinned in this skill.** Version numbers drift as datasets are revised, so confirm the exact version with `goldsky dataset get <name> --outputFormat json` rather than trusting a static list. The dataset-type and schema tables below are stable references; treat any version number in them as a starting point to validate, not ground truth.
 
 ---
 
@@ -42,8 +42,7 @@ sources:
 
 | Action             | Command                               | Notes                        |
 | ------------------ | ------------------------------------- | ---------------------------- |
-| Validate dataset     | `goldsky turbo validate file.yaml`                   | **Preferred - fast (3s)**                          |
-| Verify slug + schema | `goldsky dataset get <name> --outputFormat json`     | Exact slug, version, and schema                    |
+| Verify a dataset     | `goldsky dataset get <name> --outputFormat json`     | **Preferred** — slug, version, schema, `isTurboOnly` |
 | Search datasets      | `goldsky dataset list --output json \| grep -i name` | Non-interactive                                    |
 | List all datasets    | `goldsky dataset list --output json`                 | Plain `dataset list` is TTY-only — always `--output json` |
 

--- a/skills/mirror/SKILL.md
+++ b/skills/mirror/SKILL.md
@@ -82,7 +82,7 @@ sources:
 sources:
   base_logs:
     type: dataset
-    dataset_name: base.logs      # Use `goldsky dataset list` to discover names
+    dataset_name: base.logs      # Use `goldsky dataset list --output json` to discover names
     version: 1.0.0               # Use `goldsky dataset get <name>` for versions
     start_at: latest             # "earliest" or "latest" (default: latest)
     filter: "address = '0x...'"  # Optional — enables Fast Scan for backfills
@@ -523,8 +523,8 @@ Start small and scale up if needed. Resource size affects pricing.
 ## Dataset Discovery
 
 ```bash
-# List available datasets
-goldsky dataset list
+# List available datasets (non-interactive)
+goldsky dataset list --output json
 
 # Get schema for a specific dataset
 goldsky dataset get <dataset_name>

--- a/skills/turbo-pipelines/SKILL.md
+++ b/skills/turbo-pipelines/SKILL.md
@@ -358,7 +358,7 @@ To reset checkpoints: rename the source or pipeline. Warning: this reprocesses a
 | Deploy/Update           | `goldsky turbo apply pipeline.yaml`                    |
 | Deploy + Inspect        | `goldsky turbo apply pipeline.yaml -i`                 |
 | List pipelines          | `goldsky turbo list`                                   |
-| List datasets           | `goldsky dataset list` (slow, 30-60s)                  |
+| List datasets           | `goldsky dataset list --output json`                   |
 | List secrets            | `goldsky secret list`                                  |
 
 For lifecycle commands (pause/resume/restart/delete) and monitoring (inspect/logs), see `/turbo-operations`.


### PR DESCRIPTION
## Problem

Plain `goldsky dataset list` is an interactive `@clack` group picker. In any non-TTY context (agents, CI, pipes) it crashes with `uv_tty_init returned EINVAL` and **0 bytes on stdout** — so every `goldsky dataset list | grep <name>` recipe this skill handed agents silently returned nothing, for every agent, every time. The "slow (30–60s)" note was also wrong: it wasn't slow, it was non-functional.

## Changes

Across `datasets`, `turbo-pipelines`, and `mirror` skills:

- **Verify a slug / inspect schema:** `goldsky dataset get <name> --outputFormat json` (works, returns exact slug + version + schema).
- **List / search non-interactively:** `goldsky dataset list --output json` (optionally `--group <chain>`).
- **Version-agnostic fallback** (older CLI without the flags): the public read-only endpoint `curl -s https://api.goldsky.com/api/public/datasets/v1`.
- Added an explicit warning that bare `goldsky dataset list` is TTY-only and produces no output in an agent context, and removed the false "30–60s slow" claims.

## Coupling

The `--output`/`--group` flags and the non-TTY guard are added in **goldsky-io/goldsky#5148**. This skill PR should merge **after** that CLI change ships; until then the public-endpoint fallback documented here is the working path on the current published CLI.