### PR TITLE
TEST: verify require-version-bump check (do not merge)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "goldsky",
       "source": "./",
       "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
-      "version": "1.2.1"
+      "version": "1.2.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "goldsky",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
   "author": {
     "name": "Goldsky"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "goldsky",
   "displayName": "Goldsky",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
   "author": {
     "name": "Goldsky"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goldsky/agent-skills",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "AI-powered tools for streaming real-time blockchain data. Build, deploy, and debug Turbo pipelines.",
   "keywords": [
     "goldsky",

--- a/skills/CI_VERIFY_DELETE_ME.md
+++ b/skills/CI_VERIFY_DELETE_ME.md
@@ -1,0 +1,3 @@
+Throwaway file to verify the require-version-bump CI check on a skills/ change.
+This PR intentionally does NOT bump the version first — the check should FAIL.
+Then a bump is added — the check should PASS. The PR is closed afterward.


### PR DESCRIPTION
Throwaway PR to verify the `require-version-bump` check added in #58. First commit changes skills/ without a version bump — the check should **fail**. Then a bump is pushed — it should **pass**. Closing after.