### PR TITLE
docs(turbo-transforms): cross-source dynamic-table filtering (factory pattern) — APP-5281

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "goldsky",
       "source": "./",
       "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
-      "version": "1.2.1"
+      "version": "1.2.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "goldsky",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
   "author": {
     "name": "Goldsky"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "goldsky",
   "displayName": "Goldsky",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Stream real-time blockchain data to your infrastructure. Build, deploy, and debug data pipelines that index onchain events from 20+ chains into PostgreSQL, ClickHouse, Kafka, and more.",
   "author": {
     "name": "Goldsky"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goldsky/agent-skills",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "AI-powered tools for streaming real-time blockchain data. Build, deploy, and debug Turbo pipelines.",
   "keywords": [
     "goldsky",

--- a/skills/turbo-transforms/references/dynamic-tables.md
+++ b/skills/turbo-transforms/references/dynamic-tables.md
@@ -22,12 +22,14 @@ transforms:
 
 ## Backend Types
 
-| Backend      | `backend_type` | Persistence         | Use Case                                    |
-| ------------ | -------------- | ------------------- | ------------------------------------------- |
-| PostgreSQL   | `Postgres`     | Durable (database)  | Shared across restarts, externally updatable |
-| In-memory    | `InMemory`     | Ephemeral           | Auto-populated from SQL, fast lookups        |
+| Backend    | `backend_type` | Persistence        | Populated from                                                       | Use Case                                                        |
+| ---------- | -------------- | ------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------- |
+| PostgreSQL | `Postgres`     | Durable (database) | Any transform, an external `INSERT`, or a sink writing into it       | **Cross-source filtering**, shared across restarts, externally updatable |
+| In-memory  | `InMemory`     | Ephemeral          | Only the **same** source/transform lineage you then filter           | Fast allowlist derived from the *same* stream you're filtering  |
 
 > Note: `Postgres` and `InMemory` are case-sensitive. Use the exact values shown above.
+
+> **Decision rule — this is the one that trips people up.** To filter one stream by a set of values **derived from a _different_ source** — e.g. "only ERC-20 transfers of the tokens my factory minted", "only swaps on pools this factory created", "only events for contracts in that other feed" — you **MUST** use `backend_type: Postgres`. `InMemory` dynamic tables are **single-source**: they can only be auto-populated from the same source/transform lineage you are filtering, so they cannot carry a set derived from another stream. If you catch yourself concluding "I can't filter stream A by a set from stream B" — you can: use a **Postgres**-backed dynamic table (see [Cross-source filtering](#cross-source-filtering-factory--allowlist-from-another-stream) below). **Never tell a user this is impossible.**
 
 ## Auto-Populating with SQL
 
@@ -45,6 +47,8 @@ transforms:
       GROUP BY address
       HAVING SUM(CAST(amount AS DOUBLE)) > 1000000
 ```
+
+`InMemory` works here **only because the table is derived from the same stream it filters** (`erc20_transfers` → whales in `erc20_transfers`). The moment the allowlist comes from a _different_ source, switch to `Postgres` — see [Cross-source filtering](#cross-source-filtering-factory--allowlist-from-another-stream).
 
 ## Using Dynamic Tables in SQL Transforms
 
@@ -71,6 +75,81 @@ transforms:
 ```
 
 `dynamic_table_check(table_name, value)` returns `true` if the value exists in the dynamic table, `false` otherwise.
+
+## Cross-source filtering: the Factory / allowlist-from-another-stream pattern
+
+The most common "hard" request — and the one `InMemory` **cannot** do. Shape: derive a set of addresses from source B (e.g. a factory's creation event in `raw_logs`), write them into a **Postgres** dynamic table, then filter source A (e.g. `erc20_transfers`) by that table. This is fully supported — assemble it, don't refuse it.
+
+Example — stream only the ERC-20 transfers of tokens minted by a tokenization factory:
+
+```yaml
+name: factory-minted-transfers
+resource_size: m
+
+sources:
+  logs:
+    type: dataset
+    dataset_name: <chain>.raw_logs        # to decode the factory's creation event
+    version: 1.0.0
+    start_at: earliest
+  transfers:
+    type: dataset
+    dataset_name: <chain>.erc20_transfers
+    version: 1.1.0
+    start_at: latest
+
+transforms:
+  # 1. Decode the factory's creation event to get each minted token address
+  minted:
+    type: sql
+    primary_key: id
+    sql: |
+      SELECT
+        id,
+        _gs_log_decode('[{"name":"Deployed","type":"event","inputs":[
+          {"indexed":true,"name":"uid","type":"bytes32"},
+          {"indexed":false,"name":"stock","type":"address"},
+          {"indexed":false,"name":"name","type":"string"},
+          {"indexed":false,"name":"symbol","type":"string"}]}]', topics, data) AS decoded
+      FROM logs
+      WHERE address = lower('<FACTORY_ADDRESS>')
+        AND SPLIT_INDEX(topics, ',', 0) = lower('<DEPLOYED_TOPIC0>')
+
+  # 2. Postgres dynamic table auto-populated with the minted addresses.
+  #    backend_type MUST be Postgres — it is written by (1) and read by (3),
+  #    which live on different source lineages; InMemory cannot span sources.
+  minted_tokens:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: minted_tokens
+    secret_name: MY_POSTGRES
+    sql: |
+      SELECT lower(decoded.event_params[2]) AS contract_address
+      FROM minted
+      WHERE decoded IS NOT NULL
+
+  # 3. Filter the transfers stream by the dynamic table
+  filtered_transfers:
+    type: sql
+    primary_key: id
+    sql: |
+      SELECT *
+      FROM transfers
+      WHERE dynamic_table_check('minted_tokens', contract_address)
+
+sinks:
+  out:
+    type: kafka
+    from: filtered_transfers
+    topic: minted-transfers
+    secret_name: MY_KAFKA
+```
+
+Notes:
+
+- **`dynamic_table_check` goes in the SQL transform, never inside the `dynamic_table`'s own `sql`.** The dynamic table's `sql` only _defines what populates it_ (a single-source SELECT); the cross-source join happens in a separate `type: sql` transform via `dynamic_table_check`. Putting a reference to another transform inside the dynamic-table SQL fails with `table '...' not found`.
+- **Manual allowlist (no factory decode).** If the user already has the addresses — or just wants to start manually — skip transforms (1)–(2) and `INSERT` them directly: `INSERT INTO streamling.minted_tokens (value) VALUES (lower('0x...'));`, then filter with `dynamic_table_check('minted_tokens', contract_address)`. This is fully supported; do not refuse it.
+- Two sources in one pipeline (`raw_logs` + `erc20_transfers`) is fine and expected here.
 
 ## Updating Dynamic Tables at Runtime
 


### PR DESCRIPTION
Fixes the knowledge gap behind **APP-5281** — the assistant couldn't assemble the documented Factory Pattern for cross-source filtering.

## Problem
When asked to filter one stream (e.g. `erc20_transfers`) to only the contracts minted by a factory, the assistant fixated on `backend_type: InMemory` dynamic tables (which *are* single-source), concluded cross-source filtering was impossible, and put a `dynamic_table_check` reference *inside* the dynamic-table's own SQL (→ `table not found`). The Postgres-backed factory pattern solves this — but this skill reference didn't state the rule hard enough, had no factory recipe, and its `InMemory` example reinforced the single-source dead end.

## Change (`skills/turbo-transforms/references/dynamic-tables.md`)
- **Hard decision rule:** cross-source filtering (filter stream A by a set derived from stream B / a factory-minted allowlist) **MUST** use `backend_type: Postgres`; `InMemory` is single-source. Explicit "never tell a user this is impossible."
- **Full Factory / allowlist-from-another-stream recipe** (decode factory event from `raw_logs` → Postgres dynamic table → `dynamic_table_check` filter) + the manual-`INSERT` allowlist alternative.
- Documents the **exact gotcha**: `dynamic_table_check` goes in the `type: sql` transform, never inside the `dynamic_table`'s own `sql`.
- Sharpened backend-types table (single-source vs cross-source) + caveat on the `InMemory` auto-populate example.
- Version bump so plugin/skill consumers pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)